### PR TITLE
feat(react): useImpression 훅 추가

### DIFF
--- a/packages/react/src/hooks/useImpression.ts
+++ b/packages/react/src/hooks/useImpression.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState } from 'react';
+
+interface Options {
+  onImpressionStart?: () => void;
+  onImpressionEnd?: () => void;
+  rootMargin?: number;
+  threshold?: number;
+}
+export function useImpression({
+  onImpressionStart,
+  onImpressionEnd,
+  rootMargin = 0,
+  threshold = 0,
+}: Options) {
+  const [isImpressed, setImpressed] = useState(false);
+
+  const handleImpressionStart = useCallback(() => {
+    if (isImpressed === true) {
+      return;
+    }
+
+    onImpressionStart?.();
+    setImpressed(true);
+  }, []);
+
+  const handleImpressionEnd = useCallback(() => {
+    if (isImpressed === false) {
+      return;
+    }
+
+    onImpressionEnd?.();
+    setImpressed(false);
+  }, []);
+
+  const handleImpression = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      const currentRatio = entry.intersectionRatio;
+
+      const isHide = threshold === 0 ? !entry.isIntersecting : currentRatio < threshold;
+
+      if (isHide) {
+        handleImpressionEnd();
+      } else {
+        handleImpressionStart();
+      }
+    },
+    [handleImpressionEnd, handleImpressionStart]
+  );
+
+  const intersectionObserver = useMemo(() => {
+    if (typeof IntersectionObserver === 'undefined') {
+      return undefined;
+    }
+
+    return new IntersectionObserver(handleImpression, {
+      rootMargin: `${rootMargin}px`,
+      threshold: threshold,
+    });
+  }, [rootMargin, threshold]);
+
+  const ref = useCallback(
+    (element: Element | null) => {
+      if (intersectionObserver === undefined) {
+        return;
+      }
+
+      intersectionObserver.disconnect();
+      if (element !== null) {
+        intersectionObserver.observe(element);
+      }
+    },
+    [intersectionObserver]
+  );
+
+  return ref;
+}


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항

### react
엘리먼트의 노출 여부를 알 수 있는 `useImpression` 훅을 추가합니다.
요 녀석으로 `@lubycon/ui-kit`의 `Icon` 컴포넌트가 실제 화면에 보여질 때만 `assets.lubycon.io`로 아이콘을 요청하도록 만들 예정입니다!

```tsx
const ref = useImpression({
  onImpressionStart: () => { console.log('보인다!') },
  onImpressionEnd: () => { console.log('숨었다!') },
});

return <div ref={ref} />
```

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 