### PR TITLE
feat(react): useCombinedRefs, useScrollEvent 훅 추가

### DIFF
--- a/packages/react/src/hooks/useCombinedRef.ts
+++ b/packages/react/src/hooks/useCombinedRef.ts
@@ -1,0 +1,31 @@
+import { Ref, useCallback, MutableRefObject, RefCallback } from 'react';
+
+/**
+ * 여러 개의 ref를 합칠 수 있는 훅입니다.
+ * @example
+ * const Foo = forwardRef((props, fowardedRef) => {
+ *   const ref = useRef();
+ *   const combinedRef = useCombinedRefs(fowardedRef, ref2);
+ *
+ *   // div가 업데이트되면 ref, fowardedRef 둘 다 업데이트 됨
+ *   return <div ref={combinedRef} />
+ * });
+ */
+export default function useCombinedRefs<T>(
+  ...refs: Array<Ref<T> | RefCallback<T>>
+): RefCallback<T> {
+  const combinedRef = useCallback(
+    (value: T) => {
+      refs.forEach((ref) => {
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref != null) {
+          (ref as MutableRefObject<T>).current = value;
+        }
+      });
+    },
+    [refs]
+  );
+
+  return combinedRef;
+}

--- a/packages/react/src/hooks/useCombinedRef.ts
+++ b/packages/react/src/hooks/useCombinedRef.ts
@@ -5,7 +5,7 @@ import { Ref, useCallback, MutableRefObject, RefCallback } from 'react';
  * @example
  * const Foo = forwardRef((props, fowardedRef) => {
  *   const ref = useRef();
- *   const combinedRef = useCombinedRefs(fowardedRef, ref2);
+ *   const combinedRef = useCombinedRefs(fowardedRef, ref);
  *
  *   // div가 업데이트되면 ref, fowardedRef 둘 다 업데이트 됨
  *   return <div ref={combinedRef} />

--- a/packages/react/src/hooks/useCombinedRef.ts
+++ b/packages/react/src/hooks/useCombinedRef.ts
@@ -11,9 +11,7 @@ import { Ref, useCallback, MutableRefObject, RefCallback } from 'react';
  *   return <div ref={combinedRef} />
  * });
  */
-export default function useCombinedRefs<T>(
-  ...refs: Array<Ref<T> | RefCallback<T>>
-): RefCallback<T> {
+export default function useCombinedRefs<T>(...refs: Array<Ref<T>>): RefCallback<T> {
   const combinedRef = useCallback(
     (value: T) => {
       refs.forEach((ref) => {

--- a/packages/react/src/hooks/useScrollEvent.ts
+++ b/packages/react/src/hooks/useScrollEvent.ts
@@ -1,0 +1,20 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * 컴포넌트에 스크롤 이벤트를 추가하는 hook입니다.
+ * useEffect dependency로 hook의 인자인 ref, scrollCallback을 포함하고 있어
+ * ref, scrollCallback의 레퍼런스가 변경 될 때마다 스크롤 이벤트가 바인딩됩니다.
+ * 이 부분을 참고하셔서 성능이슈가 발생하지 않도록 잘 관리해주세요.
+ */
+const useScrollEvent = (ref: RefObject<HTMLElement>, scrollCallback: () => void) => {
+  useEffect(() => {
+    if (ref.current === null) {
+      return;
+    }
+
+    ref.current.addEventListener('scroll', scrollCallback, { passive: true });
+    return () => ref.current?.removeEventListener('scroll', scrollCallback);
+  }, [ref, scrollCallback]);
+};
+
+export default useScrollEvent;


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항
`@lubycon/ui-kit`에서 사용하던 `useCombinedRefs`, `useScroll` 훅을 `@lubycon/react`에 옮겼습니다.

### useCombinedRefs
여러 개의 ref를 합칠 수 있는 훅입니다.
```tsx
const Foo = forwardRef((props, fowardedRef) => {
  const ref = useRef();
  const combinedRef = useCombinedRefs(fowardedRef, ref2);
 
  // div가 업데이트되면 ref, fowardedRef 둘 다 업데이트 됨
  return <div ref={combinedRef} />
});
```

### useScrollEvent
```tsx
const Foo = () => {
  const ref = useRef();
  const callback = useCallback(() => {
    console.log('scroll 이벤트 발생');
  });

  useScrollEvent(ref, callback);

  return <div ref={ref} />;
};
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 