### PR TITLE
feat(react):  useClipboardCopy hook 추가

### DIFF
--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-
 /**
  * 매개변수로 주어진 string을 clipboard copy하는 함수를 반환하는 hook입니다.
  * https환경에서만 사용 가능하며, IE는 지원하지 않습니다.
@@ -10,6 +9,7 @@ import { useCallback } from 'react';
 const useClipboardCopy = (onCopyCallback: () => void) => {
   const copyString = useCallback(
     async (copyString: string) => {
+      if (typeof window === 'undefined') return null;
       try {
         await navigator.clipboard.writeText(copyString);
         if (onCopyCallback !== undefined) onCopyCallback();

--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+/**
+ * 매개변수로 주어진 string을 clipboard copy하는 함수를 반환하는 hook입니다.
+ * https환경에서만 사용 가능하며, IE는 지원하지 않습니다.
+ *
+ * @param onCopyCallback 매개변수로 주어진 string 복사 후 실행할 callback 함수
+ * @returns 매개변수로 주어진 string을 복사할 수 있는 함수를 반환합니다.
+ */
+const useClipboardCopy = (onCopyCallback: () => void) => {
+  const copyString = useCallback(
+    async (copyString: string) => {
+      try {
+        await navigator.clipboard.writeText(copyString);
+        if (onCopyCallback !== undefined) onCopyCallback();
+      } catch (error) {
+        throw error;
+      }
+    },
+    [onCopyCallback]
+  );
+
+  return {
+    copyString,
+  };
+};
+
+export default useClipboardCopy;

--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -9,7 +9,7 @@ import { useCallback } from 'react';
 const useClipboardCopy = (onCopyCallback: () => void) => {
   const copyString = useCallback(
     async (copyString: string) => {
-      if (typeof window === 'undefined') return null;
+      if (typeof navigator === 'undefined') return null;
       try {
         await navigator.clipboard.writeText(copyString);
         if (onCopyCallback !== undefined) onCopyCallback();

--- a/packages/react/src/hooks/useDidUpdate.ts
+++ b/packages/react/src/hooks/useDidUpdate.ts
@@ -3,7 +3,7 @@ import { DependencyList, useEffect, useRef } from 'react';
 /**
  *  useDidUpdate hook
  *
- *  dependency 배열의 요소가 업데이트 됐을때 콜백 함수를 실해압니다.
+ *  dependency 배열의 요소가 업데이트 됐을때 콜백 함수를 실행합니다.
  *
  * @param {Function} callback dependency 배열의 요소가 업데이트 될 때 호출 할 콜백 함수
  * @param {Array} conditions 업데이트를 트리거하는 변수 목록


### PR DESCRIPTION
## 변경사항
### react
- 매개변수로 주어진 string을 clipboard copy 하는 함수를 반환하는 hook을 추가하였습니다. 
- example
  ```javascript
  const Foo = () => {
    const { copyString } = useClipboardCopy();
    return (
     <button onClick={() => copyString('https://lubycon.io/')}>공유하기<button/>
    );
  };
  ```
