### PR TITLE
[skip ci] chore: vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "eslint.nodePath": ".yarn/sdks",
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
 }


### PR DESCRIPTION
## 변경사항
- vscode에서 탭사이즈 2 + 탭 대신 스페이스 사용하도록 명시
- 디폴트 포매터 prettier-eslint로 사용하도록 추가
  - vscode 밑에 tab 4 뜨는게 영 찜찜하기도 하고, format on save 하기 전에 명시적으로 잡아주는게 더 좋을 것 같아서 둘 다 추가해주었습니다

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
- 제 vscode 글로벌 설정이랑 루비콘 설정이랑 안맞는 부분이 있어서 추가하였습니다 🙏