### PR TITLE
fix(libraries): ssr issues

### DIFF
--- a/packages/react/src/hooks/useLocalStorage.ts
+++ b/packages/react/src/hooks/useLocalStorage.ts
@@ -1,4 +1,5 @@
 import {
+  getLocalStorageItem,
   setLocalStorageItem,
   removeLocalStorageItem,
   LocalStorageEventPayload,
@@ -31,10 +32,7 @@ export type LocalStorageReturnValue<T> = [T, (newValue: T | null) => void, () =>
 function useLocalStorage<T = string>(key: string): LocalStorageNullableReturnValue<T>;
 function useLocalStorage<T = string>(key: string, defaultValue: T): LocalStorageReturnValue<T>;
 function useLocalStorage<T = string>(key: string, defaultValue: T | null = null) {
-  const [localState, setLocalState] = useState<T | null>(
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    localStorage.getItem(key) === null ? defaultValue : tryParse(localStorage.getItem(key)!)
-  );
+  const [localState, setLocalState] = useState<T | null>(getLocalStorageItem(key));
 
   const onLocalStorageChange = (event: CustomEvent<LocalStorageEventPayload<T>> | StorageEvent) => {
     if (isTypeOflocalStorageChangeEvent<T>(event)) {

--- a/packages/react/src/hooks/useQueryParam.ts
+++ b/packages/react/src/hooks/useQueryParam.ts
@@ -20,7 +20,7 @@ export default function useQueryParam<T = string>(key: string, parser?: (value: 
     const query = parseQueryString(queryString);
 
     const value = query[key];
-    if (value == undefined) {
+    if (value === undefined) {
       setQueryParam(undefined);
     } else {
       setQueryParam(parser != null ? parser(value) : value);

--- a/packages/react/src/hooks/useQueryParam.ts
+++ b/packages/react/src/hooks/useQueryParam.ts
@@ -20,10 +20,10 @@ export default function useQueryParam<T = string>(key: string, parser?: (value: 
     const query = parseQueryString(queryString);
 
     const value = query[key];
-    if (typeof value === 'string') {
-      setQueryParam(parser != null ? parser(value) : value);
-    } else {
+    if (value == undefined) {
       setQueryParam(undefined);
+    } else {
+      setQueryParam(parser != null ? parser(value) : value);
     }
   }, []);
 

--- a/packages/react/src/hooks/useQueryParam.ts
+++ b/packages/react/src/hooks/useQueryParam.ts
@@ -1,5 +1,5 @@
 import { parseQueryString } from '@lubycon/utils';
-import { useMemo } from 'react';
+import { useState, useEffect } from 'react';
 
 /**
  * 쿼리스트링의 키를 기반으로 값을 가져옵니다. 만약 값이 존재하지 않을 경우 undefined가 반환됩니다.
@@ -13,15 +13,19 @@ import { useMemo } from 'react';
 export default function useQueryParam<T extends string = string>(key: string): T | undefined;
 export default function useQueryParam<T>(key: string, parser: (value: string) => T): T | undefined;
 export default function useQueryParam<T = string>(key: string, parser?: (value: string) => T) {
-  return useMemo(() => {
+  const [queryParam, setQueryParam] = useState<string | T | undefined>(undefined);
+
+  useEffect(() => {
     const queryString = location != null ? location.search : '';
     const query = parseQueryString(queryString);
 
     const value = query[key];
-    if (value == null) {
-      return undefined;
+    if (typeof value === 'string') {
+      setQueryParam(parser != null ? parser(value) : value);
+    } else {
+      setQueryParam(undefined);
     }
-
-    return parser != null ? parser(value) : query[key];
   }, []);
+
+  return queryParam;
 }


### PR DESCRIPTION
## 변경사항
- useLocalStorage의 기본 상태할당 로직 변경
  - 해당 상태할당에서 window 환경에 접근하기 때문에 서버사이드 환경에서 오류가 발생해서, utils의 getLocalStorageItem을 통해 기본 상태 할당해주도록 변경하였습니다
  - useEffect 부분에서 state가 null인 경우 다시 set하는 로직이 있어서 이 시점에서 로컬스토리지에 의도하는 정보가 설정됩니다
  - 동욱님이 전에 얘기주셨던 로컬스토리지랑 훅의 스테이트랑 같이 변해야 하는것 아니냐고 하신 부분은 로직중에 `onLocalStorageChange` 이벤 트에서 처리하고 있습니다 -!

- useQueryParam 리턴 로직을 useMemo에서 useState + useEffect로 변경하였습니다
  - 값이 없는 경우 undefined 리턴을 의도하시는 것 같아서 그대로 사용했습니다 -
  - 기존에 null인 경우 undefined를 리턴하도록 되어 있었는데, `query[key]`의 리턴 예상 값이 `string | undefined` 여서 undefined인 경우 그대로 undefined를 리턴하도록 변경했습니다

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
