### PR TITLE
fix: typedoc publish action 수정 [skip ci]

### DIFF
--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -20,9 +20,11 @@ jobs:
           git config --global user.email "lubycon@gmail.com"
           git config --global user.name "lubycon"
         env:
-          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GHty_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - name: Validate dependencies
         run: yarn install --immutable --immutable-cache
+      - name: Build
+        run: yarn build:all
       - name: Build Typedoc
         run: yarn docs:generate
       - name: Publish

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -21,8 +21,8 @@ jobs:
           git config --global user.name "lubycon"
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      - name: Install depedencies
-        run: yarn
+      - name: Validate dependencies
+        run: yarn install --immutable --immutable-cache
       - name: Build Typedoc
         run: yarn docs:generate
       - name: Publish

--- a/tsconfig.doc.json
+++ b/tsconfig.doc.json
@@ -1,12 +1,11 @@
 {
   "include": ["packages/*/src/**/*.ts"],
-
   "exclude": [
     "**/node_modules/**",
     "**/src/**/*.test.ts",
-    "**/src/**/__tests__/**"
+    "**/src/**/__tests__/**",
   ],
-
+  "baseUrl": "./packages",
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",


### PR DESCRIPTION
## 변경사항
 typedoc-publish.yml 
 docs:generate 실행시: @lubycon/패키지 참조를 못하는 error

[추가]
 ```
 yarn install --immutable --immutable-cache
 ```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
gitAction CI 돌렸을때 
@lubycon/패키지 참조를 못하는 error가 발생합니다. 🤔

 yarn install --immutable --immutable-cache, yarn install 과 크게 차이가 있을까요?
