### PR TITLE
refactor(react): useClipboardCopy 리팩터링

### DIFF
--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -22,7 +22,19 @@ const useClipboardCopy = (onCopyCallback?: () => void) => {
 
   const copyString = useCallback(
     async (copyString: string) => {
-      if (!navigator?.clipboard) return null;
+      if (!navigator?.clipboard) {
+        const textarea = <HTMLTextAreaElement>document.createElement('textarea');
+        textarea.value = copyString;
+        textarea.style.top = '0';
+        textarea.style.left = '0';
+        textarea.style.display = 'fixed';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        onCopyCallback?.();
+      }
       try {
         await navigator.clipboard.writeText(copyString);
         setCopiedText(copyString);

--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -40,6 +40,7 @@ const useClipboardCopy = (onCopyCallback?: () => void) => {
         setCopiedText(copyString);
         onCopyCallback?.();
       } catch (error) {
+        setCopiedText(null);
         throw error;
       }
     },

--- a/packages/react/src/hooks/useClipboardCopy.ts
+++ b/packages/react/src/hooks/useClipboardCopy.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 /**
  * 매개변수로 주어진 string을 clipboard copy하는 함수를 반환하는 hook입니다.
  * https환경에서만 사용 가능하며, IE는 지원하지 않습니다.
@@ -9,7 +9,7 @@ import { useCallback } from 'react';
  * @example
   ```javascript
     const Foo = () => {
-    const { copyString } = useClipboardCopy();
+    const [copiedText, copyString ] = useClipboardCopy();
     
     return (
      <button onClick={() => copyString('https://lubycon.io/')}>공유하기<button/>
@@ -17,13 +17,16 @@ import { useCallback } from 'react';
   };
   ```
  */
-const useClipboardCopy = (onCopyCallback: () => void) => {
+const useClipboardCopy = (onCopyCallback?: () => void) => {
+  const [copiedText, setCopiedText] = useState<string | null>(null);
+
   const copyString = useCallback(
     async (copyString: string) => {
-      if (typeof navigator === 'undefined') return null;
+      if (!navigator?.clipboard) return null;
       try {
         await navigator.clipboard.writeText(copyString);
-        if (onCopyCallback !== undefined) onCopyCallback();
+        setCopiedText(copyString);
+        onCopyCallback?.();
       } catch (error) {
         throw error;
       }
@@ -31,9 +34,7 @@ const useClipboardCopy = (onCopyCallback: () => void) => {
     [onCopyCallback]
   );
 
-  return {
-    copyString,
-  };
+  return [copiedText, copyString];
 };
 
 export default useClipboardCopy;


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항
- 카피 된 텍스트 리턴하도록 변경
- 콜백 함수 옵셔널로 변경
- Clipboard API 가 없는 경우 대응 [참고](https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined)

```jsx
function Foo() {
  const [copiedText, copy] = useClipboardCopy()
  return (
    <>
      <h1>Click to copy</h1>
      <div>
        <button onClick={() => copy('A')}>A</button>
        <button onClick={() => copy('B')}>B</button>
      </div>
      <p>Copied value: {copiedText ?? 'Nothing is copied yet!'}</p>
    </>
  )
}
```
오랜만에 루하~🙏(루비콘 하이라는 뜻)


## 집중적으로 리뷰 받고 싶은 부분이 있나요?
