### PR TITLE
fix: icons 패키지 typedoc 제외 [skip ci]

### DIFF
--- a/tsconfig.doc.json
+++ b/tsconfig.doc.json
@@ -4,6 +4,7 @@
     "**/node_modules/**",
     "**/src/**/*.test.ts",
     "**/src/**/__tests__/**",
+    "packages/icons/*"
   ],
   "baseUrl": "./packages",
   "compilerOptions": {
@@ -19,13 +20,12 @@
       "packages/logger/src/index.ts",
       "packages/react/src/index.ts",
       "packages/mattermost/src/index.ts",
-      "packages/utils/src/index.ts",
+      "packages/utils/src/index.ts"
     ],
-    "exclude": ["**/*.test.ts", "**/__tests__/**"],
     "out": "docs",
     "name":"루비콘 라이브러리 문서",
     "excludePrivate": true,
     "readme": "README.md",
-    "gitRevision": "main",
+    "gitRevision": "main"
   }
 }


### PR DESCRIPTION
## 변경사항
- 임시 icons 패키지 컴포넌트는 typedoc generate 제외 시켰습니다.