### PR TITLE
feat(utils): copyToClipboard 함수 추가

### DIFF
--- a/packages/utils/src/copyToClipboard/index.ts
+++ b/packages/utils/src/copyToClipboard/index.ts
@@ -1,0 +1,55 @@
+const getDummyTextarea = () => {
+  const textarea = document.createElement('textarea') as HTMLTextAreaElement;
+  textarea.style.top = '0';
+  textarea.style.left = '0';
+  textarea.style.display = 'fixed';
+
+  return textarea;
+};
+
+export const isClipboardSupported = () => navigator?.clipboard != null;
+export const isClipboardCommandSupported = () => document.queryCommandSupported?.('copy') ?? false;
+
+/**
+ * 인자로 받은 텍스트를 클립보드에 복사합니다.
+ *
+ * @example
+ * ```ts
+ * const result = await copyToClipboard('하이');
+ * if (result) {
+ *   console.log('클립보드에 복사 성공');
+ * } else {
+ *   console.log('클립보드에 복사 실패');
+ * }
+ * ```
+ */
+export const copyToClipboard = (text: string) => {
+  return new Promise<boolean>(async (resolve) => {
+    const rootElement = document.body;
+
+    if (isClipboardSupported()) {
+      await navigator.clipboard.writeText(text);
+      resolve(true);
+      return;
+    }
+
+    if (isClipboardCommandSupported()) {
+      const textarea = getDummyTextarea();
+      textarea.value = text;
+
+      rootElement.appendChild(textarea);
+
+      textarea.focus();
+      textarea.select();
+
+      document.execCommand('copy');
+      rootElement.removeChild(textarea);
+      resolve(true);
+      return;
+    }
+
+    resolve(false);
+  });
+};
+
+export default copyToClipboard;

--- a/packages/utils/src/deviceDetector/utils.ts
+++ b/packages/utils/src/deviceDetector/utils.ts
@@ -51,8 +51,9 @@ export function isMobile(userAgent: string) {
     'LG',
     'SAMSUNG',
   ].join('|');
-  const regExp = new RegExp(device, 'i').test(userAgent);
-  return regExp;
+  const regExp = new RegExp(device, 'i');
+
+  return regExp.test(userAgent);
 }
 
 export function getIsClientSideCheck() {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -18,3 +18,4 @@ export * from './queryString';
 export * from './promise';
 export * from './date';
 export * from './array';
+export * from './copyToClipboard';


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항
- `@lubycon/utils`에 `copyToClipboard` 함수를 추가합니다.

### copyToClipboard

내부적으로는 크로스 브라우징에 대한 예외처리를 진행하고 있지만, 함수의 출력 타입을 `Promise<boolean>`으로 통일해서, 구현을 캡슐화합니다.

```ts
const result = await copyToClipboard('하이');
if (result) {
  console.log('클립보드에 복사 성공');
} else {
  console.log('클립보드에 복사 실패');
}
```

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
`textarea.select()`를 사용하는  방법이 iOS에서 간혹 문제가 발생했던 것 같은데, 추후 이 부분에 대한 테스트가 필요할 것 같습니다.