### PR TITLE
feat(utils): createMapFromArray, createObjectFromArray 추가

### DIFF
--- a/packages/utils/src/array/createFromArray.ts
+++ b/packages/utils/src/array/createFromArray.ts
@@ -1,0 +1,46 @@
+/**
+ * 인자로 받은 배열을 기반으로 key를 키로 가지는 Map을 생성합니다.
+ *
+ * @example
+ * ```ts
+ * interface Foo {
+ *   id: string;
+ *   name: string;
+ * }
+ * const fooList: Foo[] = [];
+ * createMapFromArray(fooList, 'id'); // Map<string, Foo>
+ * ```
+ */
+export function createMapFromArray<T, K extends keyof T>(array: T[], key: K) {
+  const map = new Map<T[K], T>();
+  array.forEach((item) => {
+    map.set(item[key], item);
+  });
+
+  return map;
+}
+
+/**
+ * 인자로 받은 배열을 기반으로 key를 키로 가지는 Object를 생성합니다.
+ *
+ * @example
+ * ```ts
+ * interface Foo {
+ *   id: string;
+ *   name: string;
+ * }
+ * const fooList: Foo[] = [];
+ * createObjectFromArray(fooList, 'id'); // Record<string, Foo>
+ * ```
+ */
+export function createObjectFromArray<T extends Record<string, any>, K extends keyof T>(
+  array: T[],
+  key: K
+) {
+  const obj: Record<string, T> = {};
+  array.forEach((item) => {
+    obj[item[key]] = item;
+  });
+
+  return obj;
+}

--- a/packages/utils/src/array/createFromArray.ts
+++ b/packages/utils/src/array/createFromArray.ts
@@ -14,6 +14,10 @@
 export function createMapFromArray<T, K extends keyof T>(array: T[], key: K) {
   const map = new Map<T[K], T>();
   array.forEach((item) => {
+    if (map.get(item[key]) != null) {
+      throw new Error('이미 동일한 key가 존재합니다.');
+    }
+
     map.set(item[key], item);
   });
 
@@ -39,6 +43,10 @@ export function createObjectFromArray<T extends Record<string, any>, K extends k
 ) {
   const obj: Record<string, T> = {};
   array.forEach((item) => {
+    if (obj[item[key]] != null) {
+      throw new Error('이미 동일한 key가 존재합니다.');
+    }
+
     obj[item[key]] = item;
   });
 

--- a/packages/utils/src/array/getArrayFromCount.ts
+++ b/packages/utils/src/array/getArrayFromCount.ts
@@ -5,6 +5,6 @@
  * getArrayFromCount(5) // [0, 1, 2, 3, 4];
  * getArrayFromCount(5, i => `${i}!`); // ['0!', '1!', '2!', '3!', '4!']
  */
-export function getArrayFromCount<T>(count: number, mapper?: (i: number) => T) {
+export default function getArrayFromCount<T>(count: number, mapper?: (i: number) => T) {
   return Array.from({ length: count }, (_, i) => mapper?.(i) ?? i);
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,5 +17,6 @@ export * from './is';
 export * from './queryString';
 export * from './promise';
 export * from './date';
-export * from './array';
+export { default as getArrayFromCount } from './array/getArrayFromCount';
+export * from './array/createFromArray';
 export * from './copyToClipboard';


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항

인자로 받은 배열을 Map 구조로 변경하는 함수인 `createMapFromArray`와 `createObjectFromArray`를 추가합니다.

백엔드로 받아온 `T[]` 배열 내부의 아이템에 자주 접근해야 하는 상황이거나, 특정한 아이템을 캐싱해야하는 상황에서 유용하게 사용할 수 있습니다.

Map과 Object의 용법 자체는 크게 다르지 않지만, 키에 할당할 수 있는 타입이나 내부를 순회할 때 순서가 보장되는지 여부 등 세세한 부분에서 차이가 있으므로 두 가지 타입을 모두 제공합니다.

이 두 가지 타입의 차이에 대한 자세한 내용은 MDN의 [키기반의 컬렉션](https://developer.mozilla.org/ko/docs/Web/JavaScript/Guide/Keyed_collections) 문서를 참고해주세요.

### createMapFromArray

인자로 받은 `T[]` 배열을 기반으로 `key`를 키 값으로 가지는 Map을 생성합니다.

```ts
interface Foo {
  id: string;
  name: string;
}
const fooList: Foo[] = [];
createMapFromArray(fooList, 'id'); // Map<string, Foo>
```

### createObjectFromArray

인자로 받은 `T[]` 배열을 기반으로 `key`를 키 값으로 가지는 Object를 생성합니다.
```ts
interface Foo {
  id: string;
  name: string;
}
const fooList: Foo[] = [];
createObjectFromArray(fooList, 'id'); // Record<string, Foo>
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 