### PR TITLE
feat(utils): SVG 호 관련 유틸들 추가

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,3 +20,4 @@ export * from './date';
 export { default as getArrayFromCount } from './array/getArrayFromCount';
 export * from './array/createFromArray';
 export * from './copyToClipboard';
+export * from './svg';

--- a/packages/utils/src/svg/index.ts
+++ b/packages/utils/src/svg/index.ts
@@ -1,11 +1,11 @@
+const MAX_DEGREE = 359.9;
+
 export interface ArcData {
   x: number;
   y: number;
   radius: number;
   degree: number;
 }
-
-export const MAX_DEGREE = 359.9;
 
 /**
  * @desc 삼각함수를 사용하여 x축으로부터 시계 방향으로 degree(θ)만큼 벌어진 좌표를 구합니다
@@ -15,7 +15,7 @@ export const MAX_DEGREE = 359.9;
  * const { x, y } = getCoordsOnCircle({ x: 50, y: 50, radius: 50, degree: 90 }); // { x: 50, y: 100 }
  * ```
  */
-const getCoordsOnCircle = ({ x, y, radius, degree }: ArcData) => {
+export const getCoordsOnCircle = ({ x, y, radius, degree }: ArcData) => {
   const radian = (degree / 180) * Math.PI;
   return {
     x: x + radius * Math.cos(radian),

--- a/packages/utils/src/svg/index.ts
+++ b/packages/utils/src/svg/index.ts
@@ -1,0 +1,51 @@
+export interface ArcData {
+  x: number;
+  y: number;
+  radius: number;
+  degree: number;
+}
+
+export const MAX_DEGREE = 359.9;
+
+/**
+ * @desc 삼각함수를 사용하여 x축으로부터 시계 방향으로 degree(θ)만큼 벌어진 좌표를 구합니다
+ * @example
+ * ```ts
+ * // 중심 좌표가 (0, 0)이고 반지름이 50인 원을 기준으로 90만큼 벌어진 곳의 좌표를 구합니다
+ * const { x, y } = getCoordsOnCircle({ x: 50, y: 50, radius: 50, degree: 90 }); // { x: 50, y: 100 }
+ * ```
+ */
+const getCoordsOnCircle = ({ x, y, radius, degree }: ArcData) => {
+  const radian = (degree / 180) * Math.PI;
+  return {
+    x: x + radius * Math.cos(radian),
+    y: y + radius * Math.sin(radian),
+  };
+};
+
+/**
+ * @desc 중심 좌표 (x, y)를 기준으로 degree(θ)만큼 +방향으로 호를 그리는 패스 명령어를 반환합니다.
+ * @example
+ * ```tsx
+ * const ArcSvg = () => {
+ *   return (
+ *     <svg width={100} height={100}>
+         <path d={getArc({ x: 50, y: 50, radius: 50, degree: 90 })} fill="#000000" />
+       </svg>
+     );
+ * }
+ * ```
+ */
+export const getArc = (props: ArcData) => {
+  const startCoord = getCoordsOnCircle({ ...props, degree: 0 });
+  const finishCoord = getCoordsOnCircle({ ...props });
+
+  const { x, y, radius, degree } = props;
+  const isLargeArc = degree > 180 ? 1 : 0;
+  const isEnd = degree === MAX_DEGREE;
+
+  const d = `M ${startCoord.x} ${startCoord.y} A ${radius} ${radius} 0 ${isLargeArc} 1 ${
+    finishCoord.x
+  } ${finishCoord.y} L ${x} ${y} ${isEnd ? 'z' : ''}`;
+  return d;
+};


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항

<img width="1244" alt="스크린샷 2021-10-02 오후 5 37 28" src="https://user-images.githubusercontent.com/19145342/135709505-a38e7cde-ee75-4f2c-8f79-2700a1c662ff.png">

`@lubycon/utils`에 SVG 호를 편하게 그릴 수 있는 유틸을 추가합니다.

SVG의 호는 `circle` 처럼 따로 엘리먼트가 제공되는 것이 아니기 때문에 `path` 엘리먼트의 `A` 명령어를 사용해서 그려야 합니다.

하지만 호는 사람이 일반적으로 인식하는 "중심축 기준으로 n도 벌어진 모양"이라는 인터페이스를 가지고 있지 않고, 가상의 원을 먼저 정의하고 해당 원의 원주 위에서 시작점과 끝점을 정의하는 인터페이스를 가지고 있기 때문에, 처음 사용하는 사람에게는 다소 난해한 인터페이스입니다.

결국 호를 원하는 대로 그리기 위해서는 삼각함수를 사용해야 하는데, 이걸 매번 계산하기가 여간 귀찮은 일이 아니므로, 유틸을 추가합니다.

SVG의 호는 단순히 호를 그리는 것 뿐만 아니라 클립패스를 사용하여 도넛 차트의 애니메이션을 만드는 데에도 필수적으로 동반되기 때문에, 여러모로 활용도가 높습니다.

### getCoordsOnCircle

인자로 주어진 중심 좌표를 `x`, `y`로 가지고 반지름이 `radius` 만큼인 원을 기준으로 `degree` 만큼 벌어진 곳의 좌표를 구합니다.

```ts
getCoordsOnCircle({ x: 50, y: 50, radius: 50, degree: 90 }); // { x: 50, y: 100 }
```

### getArc

중심 좌표 (x, y)를 기준으로 `degree(θ)`만큼 시계 방향으로 호를 그리는 SVG 패스 명령어를 반환합니다.

```tsx
const ArcSvg = () => {
  return (
    <svg width={100} height={100}>
      <path d={getArc({ x: 50, y: 50, radius: 50, degree: 90 })} fill="#000000" />
    </svg>
  );
}
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?

SVG로 그리는 호의 원리가 잘 이해되지 않는 분들은 [SVG와 삼각 함수로 도넛 차트 만들어보기](https://evan-moon.github.io/2020/12/12/draw-arc-with-svg-clippath/) 포스팅을 한번 읽어보시거나 저에게 직접 질문 주시면 빠르게 답변드리겠습니다! 🙇‍♂️