### PR TITLE
feat(utils): cookie 유틸 추가

### DIFF
--- a/packages/utils/jest.config.json
+++ b/packages/utils/jest.config.json
@@ -2,10 +2,11 @@
   "transform": {
     "^.+\\.ts$": "babel-jest",
     "^.+\\.js$": "babel-jest"
-},
-"testRegex": "\\.test\\.js$",
-"moduleFileExtensions": [
-    "ts",
-    "js"
-]
+  },
+  "testRegex": "\\.test\\.js$",
+  "moduleFileExtensions": [
+      "ts",
+      "js"
+  ],
+  "verbose": true
 }

--- a/packages/utils/src/cookies/getOptionValue.ts
+++ b/packages/utils/src/cookies/getOptionValue.ts
@@ -1,0 +1,17 @@
+import { identify } from '../functions';
+
+export function getOptionValue<T>(key: string, v?: T | null): string;
+export function getOptionValue<T, K>(
+  key: string,
+  v: T | undefined | null,
+  parser: (v: T) => K
+): string;
+export function getOptionValue<T, K>(key: string, v?: T | null, parser?: (v: T) => K) {
+  if (v == null) {
+    return '';
+  }
+
+  const finalParser = parser ?? identify;
+  const parsedValue = finalParser<T>(v);
+  return `${key}=${parsedValue};`;
+}

--- a/packages/utils/src/cookies/index.ts
+++ b/packages/utils/src/cookies/index.ts
@@ -1,0 +1,56 @@
+import { identify } from '../functions';
+import { parseCookies } from './parseCookies';
+import { CookieValue, SetCookieOptions, stringifyCookie } from './stringifyCookie';
+
+/**
+ * 쿠키에 값을 세팅합니다. expires, path 등의 쿠키 옵션을 사용할 수 있습니다.
+ *
+ * @example
+ * ```ts
+ * setCookie('foo', 1);
+ * setCookie('foo', 1, { expires: new Date(2022, 1, 15) });
+ * ```
+ */
+export function setCookie<T extends CookieValue>(
+  key: string,
+  value: T,
+  options?: SetCookieOptions
+) {
+  document.cookie = stringifyCookie(key, value, options);
+}
+
+/**
+ * 전체 쿠키를 가져옵니다. 만약 쿠키가 없는 경우에는 빈 객체를 반환합니다.
+ *
+ * @example
+ * ```ts
+ * const { foo } = getCookies();
+ * console.log(foo);
+ * ```
+ */
+export function getCookies() {
+  return parseCookies(document.cookie);
+}
+
+/**
+ * 인자로 주어진 key에 해당하는 쿠키를 가져옵니다. 만약 해당 쿠키가 존재하지 않는 경우 undefined를 반환합니다.
+ *
+ * @example
+ * ```ts
+ * const foo = getCookie('foo'); // string | undefined;
+ * const foo = getCookie('foo', Number); // number | undefined;
+ * const foo = getCookie('foo', v => [v]) // string[] | undefined;
+ * ```
+ */
+export function getCookie<T extends string>(key: string): T | undefined;
+export function getCookie<T>(key: string, parser: (v: string) => T): T | undefined;
+export function getCookie<T = string>(key: string, parser?: (v: string) => T) {
+  const cookies = getCookies();
+  const value = cookies[key];
+  if (value == null) {
+    return undefined;
+  }
+
+  const finalParser = parser ?? identify;
+  return finalParser(value);
+}

--- a/packages/utils/src/cookies/parseCookies.ts
+++ b/packages/utils/src/cookies/parseCookies.ts
@@ -1,0 +1,10 @@
+export function parseCookies(cookieString: string): Record<string, string> {
+  const arr = cookieString.split(';');
+  return arr.reduce((prev, current) => {
+    const [key, value] = current.split('=');
+    return {
+      ...prev,
+      [key.trim()]: value,
+    };
+  }, {});
+}

--- a/packages/utils/src/cookies/stringifyCookie.ts
+++ b/packages/utils/src/cookies/stringifyCookie.ts
@@ -1,0 +1,29 @@
+import { getOptionValue } from './getOptionValue';
+
+export type CookieValue = string | boolean | number;
+export interface SetCookieOptions {
+  expires?: Date;
+  path?: string;
+  domain?: string;
+  maxAge?: number;
+}
+
+export function stringifyCookie<T extends CookieValue>(
+  key: string,
+  value: T,
+  options: SetCookieOptions = {}
+) {
+  const cookieValue = `${key}=${encodeURIComponent(String(value))};`;
+
+  if (options == null) {
+    return cookieValue;
+  }
+
+  const { expires, path, domain, maxAge } = options;
+  return `${cookieValue} ${getOptionValue('expires', expires, (v) =>
+    v.toUTCString()
+  )} ${getOptionValue('path', path)} ${getOptionValue('domain', domain)} ${getOptionValue(
+    'max-age',
+    maxAge
+  )}`.trim();
+}

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -1,0 +1,1 @@
+export const identify = <T>(v: T) => v;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -23,3 +23,4 @@ export * from './copyToClipboard';
 export * from './svg';
 export * from './fetch';
 export * from './uuid';
+export * from './cookies';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -24,3 +24,4 @@ export * from './svg';
 export * from './fetch';
 export * from './uuid';
 export * from './cookies';
+export * from './functions';

--- a/packages/utils/test/cookies.test.js
+++ b/packages/utils/test/cookies.test.js
@@ -1,0 +1,32 @@
+import { stringifyCookie } from '../src/cookies/stringifyCookie';
+import { parseCookies } from '../src/cookies/parseCookies';
+
+describe('cookies', () => {
+  describe('stringifyCookie', () => {
+    test(`stringifyCookie 함수는 string 타입의 값을 처리할 수 있다.`, () => {
+      expect(stringifyCookie('foo', 'test')).toBe(`foo=test;`);
+    });
+    test(`stringifyCookie 함수는 boolean 타입의 값을 처리할 수 있다.`, () => {
+      expect(stringifyCookie('foo', true)).toBe(`foo=true;`);
+    });
+    test(`stringifyCookie 함수는 number 타입의 값을 처리할 수 있다.`, () => {
+      expect(stringifyCookie('foo', 1)).toBe(`foo=1;`);
+    });
+    test(`stringifyCoookie 함수는 쿠키의 옵션을 처리할 수 있다`, () => {
+      expect(stringifyCookie('foo', 1, { expires: new Date(2022, 1, 12), path: '/' })).toBe(
+        `foo=1; expires=Fri, 11 Feb 2022 15:00:00 GMT; path=/;`
+      );
+    });
+  });
+  describe('parseCookies', () => {
+    test('parseCookie 함수는 주어진 쿠키 포맷의 문자열을 파싱하여 올바른 객체를 반환한다', () => {
+      expect(parseCookies('foo=1')).toEqual({ foo: '1' });
+    });
+    test('parseCookie 함수는 key=value 형태로 구성되지 않은 문자열을 무시한다', () => {
+      expect(parseCookies('foo=true; bar123')).toEqual({ foo: 'true' });
+    });
+    test('parseCookie 함수는 쿠키가 없는 경우, 빈 객체를 반환한다', () => {
+      expect(parseCookies('')).toEqual({});
+    });
+  });
+});

--- a/packages/utils/test/is.test.js
+++ b/packages/utils/test/is.test.js
@@ -1,19 +1,21 @@
 import { isBoolean, isNumber, isString } from '../src/is/index';
 
-test('check if value is string type', () => {
-  expect(isString('test')).toBe(true);
-  expect(isString(1000)).toBe(false);
-  expect(isString(true)).toBe(false);
-});
+describe('is', () => {
+  test('isString 함수는 string 타입을 인자로 받으면 true, 아니면 false를 반환한다', () => {
+    expect(isString('test')).toBe(true);
+    expect(isString(1000)).toBe(false);
+    expect(isString(true)).toBe(false);
+  });
 
-test('check if value is number type', () => {
-  expect(isNumber('test')).toBe(false);
-  expect(isNumber(1000)).toBe(true);
-  expect(isNumber(true)).toBe(false);
-});
+  test('isNumber 함수는 number 타입을 인자로 받으면 true, 아니면 false를 반환한다', () => {
+    expect(isNumber('test')).toBe(false);
+    expect(isNumber(1000)).toBe(true);
+    expect(isNumber(true)).toBe(false);
+  });
 
-test('check if value is boolean type', () => {
-  expect(isBoolean('test')).toBe(false);
-  expect(isBoolean(1000)).toBe(false);
-  expect(isBoolean(true)).toBe(true);
+  test('isBoolean 함수는 boolean 타입을 인자로 받으면 true, 아니면 false를 반환한다', () => {
+    expect(isBoolean('test')).toBe(false);
+    expect(isBoolean(1000)).toBe(false);
+    expect(isBoolean(true)).toBe(true);
+  });
 });


### PR DESCRIPTION
## 변경사항
Cookie를 관리할 수 있는 유틸 함수를 추가합니다.

그리고 자매품으로 항등함수인 `identify` 함수도 하나 추가합니다. 이 함수의 용도는 주로 함수를 합성할 때 함수의 공역을 제한하고, 쓸데없는 사이드 이펙트의 발생을 방지하기 위해 사용합니다. 혹시 잘 이해가 안 가신다면 `getOptionValue` 같은 함수를 보시면 금방 아실 수 있을 것 같슴다. 🙏 

```ts
setCookie('foo', 1);
setCookie('bar', 1, { expires: new Date('2021-11-25') });

const cookies = getCookies(); // Record<string, string>
const foo2 = getCookie('foo') // string | undefined
const foo3 = getCookie('foo', Number) // number | undefined
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow: