### PR TITLE
feat(temen): differenceWith 함수 추가

### DIFF
--- a/packages/temen/src/difference/index.ts
+++ b/packages/temen/src/difference/index.ts
@@ -1,0 +1,18 @@
+/**
+ * 두 배열 간의 동일하지 않은 원소를 담은 배열을 반환합니다. 이때 동일 여부는 세 번째 인자인 comparator 함수로 판단합니다.
+ *
+ * @example
+ * ```ts
+ * differenceWith([1, 2, 3], [2, 3], (x, y) => x === y); // [1]
+ * differenceWith(
+ *   [{ info: { id: 1 }, name: 'evan' }, { info: { id: 2 }, name: 'john' }],
+ *   [{ info: { id: 2 }, name: 'john' }],
+ *   (x, y) => x.info.id === y.info.id
+ * ); // [{ info: { id: 1 }, name: 'evan' }]
+ * ```
+ */
+export function differenceWith<T>(xs: T[], ys: T[], comparator: (x: T, y: T) => boolean): T[] {
+  return xs.filter((x) => {
+    return ys.find((y) => comparator(x, y)) == null;
+  });
+}

--- a/packages/temen/src/difference/index.ts
+++ b/packages/temen/src/difference/index.ts
@@ -13,6 +13,6 @@
  */
 export function differenceWith<T>(xs: T[], ys: T[], comparator: (x: T, y: T) => boolean): T[] {
   return xs.filter((x) => {
-    return ys.find((y) => comparator(x, y)) == null;
+    return ys.findIndex((y) => comparator(x, y)) === -1; // 찾는 원소가 null이나 undefined면 망함
   });
 }

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -30,3 +30,4 @@ export { default as chunk } from './chunk';
 export { default as cloneDeep } from './cloneDeep';
 export { default as clone } from './clone';
 export { default as castArray } from './castArray';
+export * from './difference';

--- a/packages/temen/test/diffference.test.js
+++ b/packages/temen/test/diffference.test.js
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import { differenceWith } from '../src/difference';
+
+describe('differenceWith', () => {
+  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다.', function () {
+    assert.deepStrictEqual(
+      differenceWith([0, 1, 2, 3, 4, 5], [0, 1, 2], (x, y) => x === y),
+      [3, 4, 5]
+    );
+  });
+  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다.', function () {
+    assert.deepStrictEqual(
+      differenceWith(
+        [
+          { info: { id: 1 }, name: 'evan' },
+          { info: { id: 2 }, name: 'john' },
+        ],
+        [{ info: { id: 2 }, name: 'john' }],
+        (x, y) => x.info.id === y.info.id
+      ),
+      [{ info: { id: 1 }, name: 'evan' }]
+    );
+  });
+});

--- a/packages/temen/test/diffference.test.js
+++ b/packages/temen/test/diffference.test.js
@@ -8,6 +8,12 @@ describe('differenceWith', () => {
       [3, 4, 5]
     );
   });
+  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다. (null, undefined)', function () {
+    assert.deepStrictEqual(
+      differenceWith([null, undefined], [null], (x, y) => x === y),
+      [undefined]
+    );
+  });
   it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다. (복잡한 타입)', function () {
     assert.deepStrictEqual(
       differenceWith(
@@ -19,6 +25,12 @@ describe('differenceWith', () => {
         (x, y) => x.info.id === y.info.id
       ),
       [{ info: { id: 1 }, name: 'evan' }]
+    );
+  });
+  it('differenceWith 함수는 같은 배열이 들어오면 빈 배열을 반환한다.', function () {
+    assert.deepStrictEqual(
+      differenceWith([{ foo: 1 }], [{ foo: 1 }], (x, y) => x.foo === y.foo),
+      []
     );
   });
 });

--- a/packages/temen/test/diffference.test.js
+++ b/packages/temen/test/diffference.test.js
@@ -2,13 +2,13 @@ import assert from 'assert';
 import { differenceWith } from '../src/difference';
 
 describe('differenceWith', () => {
-  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다.', function () {
+  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다. (원시 타입)', function () {
     assert.deepStrictEqual(
       differenceWith([0, 1, 2, 3, 4, 5], [0, 1, 2], (x, y) => x === y),
       [3, 4, 5]
     );
   });
-  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다.', function () {
+  it('differenceWith 함수는 인자로 받은 두 배열의 차이를 반환할 수 있다. (복잡한 타입)', function () {
     assert.deepStrictEqual(
       differenceWith(
         [


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항
인자로 주어진 두 배열 간의 차이점을 반환하는 `differenceWith` 함수를 추가합니다.
`differenceWith + deepEqual` 함수가 `difference<T>(x: T[], y: T[])`  함수이기 때문에, `difference` 함수를 만들기 위한 재료이기도 합니다.

```ts
differenceWith([1, 2, 3], [2, 3], (x, y) => x === y); // [1]
differenceWith(
  [{ info: { id: 1 }, name: 'evan' }, { info: { id: 2 }, name: 'john' }],
  [{ info: { id: 2 }, name: 'john' }],
  (x, y) => x.info.id === y.info.id
); // [{ info: { id: 1 }, name: 'evan' }]
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow: