### PR TITLE
feat(temen): zip 함수 추가

### DIFF
--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -35,3 +35,4 @@ export { default as compact } from './compact';
 export { default as pick } from './pick';
 export * from './isEqual';
 export { default as cloneWith } from './cloneWith';
+export { default as zip } from './zip';

--- a/packages/temen/src/zip/index.ts
+++ b/packages/temen/src/zip/index.ts
@@ -1,0 +1,47 @@
+import getArrayFromCount from '../getArrayFromCount';
+
+/**
+ * 인자로 주어진 배열들의 같은 인덱스에 있는 원소들끼리 그룹핑합니다.
+ *
+ * 순회는 인자로 주어진 배열들 중 가장 긴 배열의 길이를 기준으로 수행되며, 만약 해당 인덱스에 대응하는 원소가 없다면 그 자리는 undefined로 채워집니다.
+ * @example
+ * ```ts
+ * zip(['a', 'b'], [1, 2]);
+ * // [['a', 1], ['b', 2]]
+ *
+ * zip(['a', 'b'], [1, 2, 3]);
+ * // [['a', 1], ['b', 2], [undefined, 3]]
+ * ```
+ */
+function zip<T1, T2>(array1: T1[], array2: T2[]): Array<[T1 | undefined, T2 | undefined]>;
+function zip<T1, T2, T3>(
+  array1: T1[],
+  array2: T2[],
+  array3: T3[]
+): Array<[T1 | undefined, T2 | undefined, T3 | undefined]>;
+function zip<T1, T2, T3, T4>(
+  array1: T1[],
+  array2: T2[],
+  array3: T3[],
+  array4: T4[]
+): Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined]>;
+function zip<T1, T2, T3, T4, T5>(
+  array1: T1[],
+  array2: T2[],
+  array3: T3[],
+  array4: T4[],
+  array5: T5[]
+): Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined, T5 | undefined]>;
+function zip(...arrays: any[]) {
+  const longestLength = arrays.reduce((prevArrayLength: number, current: any[]) => {
+    return Math.max(prevArrayLength, current.length);
+  }, 0);
+
+  return getArrayFromCount(longestLength).map((_, i) => {
+    return getArrayFromCount(arrays.length).map((_, j) => {
+      return arrays[j][i];
+    });
+  });
+}
+
+export default zip;

--- a/packages/temen/test/zip.test.js
+++ b/packages/temen/test/zip.test.js
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import zip from '../src/zip';
+
+describe('zip', () => {
+  it('zip 함수는 인자로 받은 배열의 같은 인덱스에 있는 원소를 그룹핑할 수 있다.', function () {
+    assert.deepStrictEqual(zip(['a', 'b'], [1, 2], [true, false]), [
+      ['a', 1, true],
+      ['b', 2, false],
+    ]);
+  });
+  it('zip 함수는 인자로 받은 배열 중 가장 긴 배열을 기준으로 순회를 돈다.', function () {
+    assert.deepStrictEqual(zip(['a', 'b', 'foo'], [1, 2], [true, false]), [
+      ['a', 1, true],
+      ['b', 2, false],
+      ['foo', undefined, undefined],
+    ]);
+    assert.deepStrictEqual(zip(['a', 'b'], [1, 2, 100], [true, false]), [
+      ['a', 1, true],
+      ['b', 2, false],
+      [undefined, 100, undefined],
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [ x ] 내가 만든 모듈을 `export` 했나요?
- [ x ] 테스트는 작성했나요?
- [ x ] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

인자로 받은 배열들 내에서 같은 인덱스에 있는 원소들을 그룹핑하는 `zip` 함수를 추가합니다.

lodash 스펙은 [여기](https://lodash.com/docs/4.17.15#zip)

```ts
zip(['a', 'b'], [1, 2]);
// [['a', 1], ['b', 2]]

zip(['a', 'b'], [1, 2, 3]);
// [['a', 1], ['b', 2], [undefined, 3]]
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
타입스크립트의 오버로딩의 한계로 인해 5개의 인자까지만 받을 수 있도록 타이핑되었습니다 ㅜㅜㅜㅜ....
lodash도 그렇고 예전에 RxJS도 그렇고 이런 식으로 구현하던데...더 좋은 방법이 없을까유 🧐