### PR TITLE
feat(temen): uniq, uniqBy 함수 추가

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -23,6 +23,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:."
       },
       {
+        "name": "browser-toolkit",
+        "reference": "workspace:packages/browser-toolkit"
+      },
+      {
         "name": "@lubycon/icons",
         "reference": "workspace:packages/icons"
       },
@@ -50,6 +54,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@lubycon/logger", ["workspace:packages/logger"]],
       ["@lubycon/mattermost", ["workspace:packages/mattermost"]],
       ["@lubycon/react", ["virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#workspace:packages/react", "workspace:packages/react"]],
+      ["browser-toolkit", ["workspace:packages/browser-toolkit"]],
       ["lubycon-frontend-libraries", ["workspace:."]],
       ["temen", ["workspace:packages/temen"]]
     ],
@@ -6008,11 +6013,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:17.0.2"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],
@@ -6032,11 +6037,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["firebase", "npm:8.8.1"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["temen", "workspace:packages/temen"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
@@ -6056,11 +6061,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["path", "npm:0.12.7"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["temen", "workspace:packages/temen"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
@@ -6081,11 +6086,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:17.0.2"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["temen", "workspace:packages/temen"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
@@ -6107,11 +6112,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["cross-env", "npm:5.2.1"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["temen", "workspace:packages/temen"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
@@ -8083,6 +8088,36 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["browser-process-hrtime", "npm:1.0.0"]
           ],
           "linkType": "HARD",
+        }]
+      ]],
+      ["browser-toolkit", [
+        ["workspace:packages/browser-toolkit", {
+          "packageLocation": "./packages/browser-toolkit/",
+          "packageDependencies": [
+            ["browser-toolkit", "workspace:packages/browser-toolkit"],
+            ["@babel/core", "npm:7.15.5"],
+            ["@babel/preset-env", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:7.15.6"],
+            ["@babel/preset-typescript", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:7.15.0"],
+            ["@types/amplitude-js", "npm:8.0.1"],
+            ["@types/jest", "npm:27.0.1"],
+            ["@types/node", "npm:10.17.60"],
+            ["babel-jest", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:27.2.0"],
+            ["cross-env", "npm:5.2.1"],
+            ["cross-fetch", "npm:3.1.4"],
+            ["date-fns", "npm:2.23.0"],
+            ["jest", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:27.2.0"],
+            ["rimraf", "npm:2.7.1"],
+            ["rollup", "npm:2.55.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
+            ["rollup-plugin-json", "npm:3.1.0"],
+            ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
+            ["temen", "workspace:packages/temen"],
+            ["tslib", "npm:2.3.0"],
+            ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
+          ],
+          "linkType": "SOFT",
         }]
       ]],
       ["browserslist", [
@@ -16485,10 +16520,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
-        ["virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0", {
-          "packageLocation": "./.yarn/__virtual__/rollup-plugin-commonjs-virtual-80af3e5bcf/0/cache/rollup-plugin-commonjs-npm-10.1.0-6b5ee23ea9-396fc4d536.zip/node_modules/rollup-plugin-commonjs/",
+        ["virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0", {
+          "packageLocation": "./.yarn/__virtual__/rollup-plugin-commonjs-virtual-1f564b3374/0/cache/rollup-plugin-commonjs-npm-10.1.0-6b5ee23ea9-396fc4d536.zip/node_modules/rollup-plugin-commonjs/",
           "packageDependencies": [
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["@types/rollup", null],
             ["estree-walker", "npm:0.6.1"],
             ["is-reference", "npm:1.2.1"],
@@ -16531,10 +16566,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
-        ["virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2", {
-          "packageLocation": "./.yarn/__virtual__/rollup-plugin-sourcemaps-virtual-8bcbc9512e/0/cache/rollup-plugin-sourcemaps-npm-0.4.2-32db378741-c50dc47432.zip/node_modules/rollup-plugin-sourcemaps/",
+        ["virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2", {
+          "packageLocation": "./.yarn/__virtual__/rollup-plugin-sourcemaps-virtual-239347895e/0/cache/rollup-plugin-sourcemaps-npm-0.4.2-32db378741-c50dc47432.zip/node_modules/rollup-plugin-sourcemaps/",
           "packageDependencies": [
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
             ["@types/rollup", null],
             ["rollup", "npm:2.55.0"],
             ["rollup-pluginutils", "npm:2.8.2"],
@@ -16555,10 +16590,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
-        ["virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0", {
-          "packageLocation": "./.yarn/__virtual__/rollup-plugin-typescript2-virtual-19de370cc3/0/cache/rollup-plugin-typescript2-npm-0.30.0-f985b92bb6-e3097bb25c.zip/node_modules/rollup-plugin-typescript2/",
+        ["virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0", {
+          "packageLocation": "./.yarn/__virtual__/rollup-plugin-typescript2-virtual-4632123648/0/cache/rollup-plugin-typescript2-npm-0.30.0-f985b92bb6-e3097bb25c.zip/node_modules/rollup-plugin-typescript2/",
           "packageDependencies": [
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["@rollup/pluginutils", "npm:4.1.1"],
             ["@types/rollup", null],
             ["@types/typescript", null],
@@ -17653,11 +17688,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:27.2.0"],
             ["rimraf", "npm:2.7.1"],
             ["rollup", "npm:2.55.0"],
-            ["rollup-plugin-commonjs", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:10.1.0"],
+            ["rollup-plugin-commonjs", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:10.1.0"],
             ["rollup-plugin-json", "npm:3.1.0"],
             ["rollup-plugin-pnp-resolve", "npm:2.0.0"],
-            ["rollup-plugin-sourcemaps", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.4.2"],
-            ["rollup-plugin-typescript2", "virtual:eb2d11e538b9cd8e41dc79875b6e8a71cff399933c4258241016b915276a858cc3bfabb6a1473f82da17d6f400e528a681aa711a47cad4bb303e17456e77c140#npm:0.30.0"],
+            ["rollup-plugin-sourcemaps", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.4.2"],
+            ["rollup-plugin-typescript2", "virtual:c44350362dadf573585fbfca0a9553ff425b0c5ca93363885468a9da31bcb072b496806ceef207f28aebcf7986ad01a1d01da16718ade201313bccb226551fe4#npm:0.30.0"],
             ["tslib", "npm:2.3.0"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -39,3 +39,4 @@ export { default as conformsTo } from './conformsTo';
 export { default as cloneDeepWith } from './cloneDeepWith';
 export { default as zip } from './zip';
 export { default as unzip } from './unzip';
+export * from './uniq';

--- a/packages/temen/src/uniq/index.ts
+++ b/packages/temen/src/uniq/index.ts
@@ -8,12 +8,7 @@
  * ```
  */
 export function uniq<T>(arr: T[]): T[] {
-  const set = new Set<T>();
-  arr.forEach((item) => {
-    set.add(item);
-  });
-
-  return Array.from(set);
+  return Array.from(new Set<T>(arr));
 }
 
 /**

--- a/packages/temen/src/uniq/index.ts
+++ b/packages/temen/src/uniq/index.ts
@@ -1,0 +1,31 @@
+/**
+ * 인자로 주어진 배열 내의 중복된 원소를 제거합니다. 같은 값을 가진 원소를 걸러내기 때문에 Object와 같은 자료형의 중복은 체크하지 않습니다.
+ *
+ * @example
+ * ```ts
+ * uniq([1, 1, 2, 3, 5, 5, 7, 'foo', 'bar', 'bar']);
+ * // [1, 2, 3, 5, 7, 'foo', 'bar']
+ * ```
+ */
+export function uniq<T>(arr: T[]): T[] {
+  const set = new Set<T>();
+  arr.forEach((item) => {
+    set.add(item);
+  });
+
+  return Array.from(set);
+}
+
+/**
+ * 두 번째 인자인 converter 함수로 배열의 원소를 매핑한 후, 중복된 원소를 제거합니다. 같은 값을 가진 원소를 걸러내기 때문에 Object와 같은 자료형의 중복은 체크하지 않습니다.
+ *
+ * @example
+ * ```ts
+ * uniqBy([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], Math.floor);
+ * // [1, 2, 3, 5, 7]
+ * ```
+ */
+export function uniqBy<T, U>(arr: T[], converter: (item: T) => U): U[] {
+  const mappedArray = arr.map(converter);
+  return uniq(mappedArray);
+}

--- a/packages/temen/test/isEqual.test.js
+++ b/packages/temen/test/isEqual.test.js
@@ -7,13 +7,6 @@ const generateMap = (object) => {
   }
   return map;
 };
-const generateSet = (arr) => {
-  const set = new Set();
-  for (const i of arr) {
-    set.add(arr[i]);
-  }
-  return set;
-};
 
 describe('isEqual', () => {
   test('isEqual는 원시자료형을 비교할 수 있다', () => {
@@ -46,8 +39,8 @@ describe('isEqual', () => {
     expect(
       isEqual(generateMap({ name: 'evan', age: 31 }), generateMap({ name: 'evan', age: 12 }))
     ).toBe(false);
-    expect(isEqual(generateSet([1, 2, 3]), generateSet([1, 2, 3]))).toBe(true);
-    expect(isEqual(generateSet([1, 2, 3]), generateSet([1, 2]))).toBe(false);
+    expect(isEqual(new Set([1, 2, 3]), new Set([1, 2, 3]))).toBe(true);
+    expect(isEqual(new Set([1, 2, 3]), new Set([1, 2]))).toBe(false);
   });
   test('isEqual는 객체를 비교할 수 있다', () => {
     expect(isEqual({ name: 'evan' }, { name: 'evan' })).toBe(true);

--- a/packages/temen/test/uniq.test.js
+++ b/packages/temen/test/uniq.test.js
@@ -13,6 +13,10 @@ describe('uniq', () => {
       'bar',
     ]);
   });
+  it('uniq 함수는 배열 내에서 중복되는 레퍼런스를 가진 원소를 제거한다', function () {
+    const o = { id: 1 };
+    assert.deepStrictEqual(uniq([o, o]), [{ id: 1 }]);
+  });
 });
 
 describe('uniqBy', () => {

--- a/packages/temen/test/uniq.test.js
+++ b/packages/temen/test/uniq.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { uniq, uniqBy } from '../src/uniq';
+
+describe('uniq', () => {
+  it('uniq 함수는 배열 내에서 중복되는 값을 가진 원소를 제거한다', function () {
+    assert.deepStrictEqual(uniq([1, 1, 2, 3, 5, 5, 7, 'foo', 'bar', 'bar']), [
+      1,
+      2,
+      3,
+      5,
+      7,
+      'foo',
+      'bar',
+    ]);
+  });
+});
+
+describe('uniqBy', () => {
+  it('uniqBy 함수는 배열의 원소들을 mapping한 후, 중복되는 값을 가진 원소를 제거한다', function () {
+    assert.deepStrictEqual(
+      uniqBy([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], Math.floor),
+      [1, 2, 3, 5, 7]
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4973,6 +4973,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-toolkit@workspace:packages/browser-toolkit":
+  version: 0.0.0-use.local
+  resolution: "browser-toolkit@workspace:packages/browser-toolkit"
+  dependencies:
+    "@babel/core": ^7.15.5
+    "@babel/preset-env": ^7.15.6
+    "@babel/preset-typescript": ^7.15.0
+    "@types/amplitude-js": ^8.0.0
+    "@types/jest": ^27.0.1
+    "@types/node": ^10.11.0
+    babel-jest: ^27.2.0
+    cross-env: ^5.2.0
+    cross-fetch: ^3.1.4
+    date-fns: ^2.22.1
+    jest: ^27.2.0
+    rimraf: ^2.6.2
+    rollup: ^2.38.5
+    rollup-plugin-commonjs: ^10.1.0
+    rollup-plugin-json: ^3.1.0
+    rollup-plugin-pnp-resolve: ^2.0.0
+    rollup-plugin-sourcemaps: ^0.4.2
+    rollup-plugin-typescript2: ^0.30.0
+    temen: "workspace:packages/temen"
+    tslib: ^2.3.0
+    typescript: ^4.3.5
+  languageName: unknown
+  linkType: soft
+
 "browserslist@npm:^4.16.6, browserslist@npm:^4.17.0":
   version: 4.17.0
   resolution: "browserslist@npm:4.17.0"


### PR DESCRIPTION
## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
배열 내의 중복되는 원소를 제거하는 `uniq`, `uniqBy` 함수를 추가합니다.

lodash는 직접 배열을 순회돌며 `include 되어있니?`를 계속 물어보는 식으로 작성되어있던데, 유일한 값이나 레퍼런스만을 받아들이는 [Set](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Set)의 특성을 사용하면 굳이 이럴 필요없이 한 큐에 해결됩니다.

```ts
uniq([1, 1, 2, 3, 5, 5, 7, 'foo', 'bar', 'bar']); // [1, 2, 3, 5, 7, 'foo', 'bar']

const o = { id: 1 };
const array = uniq([o, o]); // [{ id: 1 }]
array[0] === o; // true, 원소의 레퍼런스는 변하지 않는다.

uniqBy([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], Math.floor); // [1, 2, 3, 5, 7]
```

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow: