### PR TITLE
feat(temen): sum, max, min 함수 추가

### DIFF
--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -42,3 +42,4 @@ export { default as unzip } from './unzip';
 export * from './uniq';
 export * from './intersection';
 export * from './sum';
+export * from './max';

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -41,3 +41,4 @@ export { default as zip } from './zip';
 export { default as unzip } from './unzip';
 export * from './uniq';
 export * from './intersection';
+export * from './sum';

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -43,3 +43,4 @@ export * from './uniq';
 export * from './intersection';
 export * from './sum';
 export * from './max';
+export * from './min';

--- a/packages/temen/src/max/index.ts
+++ b/packages/temen/src/max/index.ts
@@ -1,0 +1,28 @@
+/**
+ * 인자로 받은 배열의 원소들 중 최대 값을 반환합니다.
+ *
+ * @example
+ * ```ts
+ * max([1, 2, 3, 4]); // 4
+ * ```
+ */
+export function max(array: number[]) {
+  return Math.max(...array);
+}
+
+/**
+ * 인자로 받은 배열을 매핑한 후 결과 값에 따라 최대 값을 가진 원소를 반환합니다.
+ *
+ * @example
+ * ```ts
+ * maxBy(
+ *   [{ value: 1 }, { value: 2 }, { value: 3 }],
+ *   item => item.value
+ * ); // { value: 3 }
+ * ```
+ */
+export function maxBy<T>(array: T[], mapper: (item: T) => number) {
+  return array.reduce((prev, current) => {
+    return mapper(prev) > mapper(current) ? prev : current;
+  });
+}

--- a/packages/temen/src/min/index.ts
+++ b/packages/temen/src/min/index.ts
@@ -1,0 +1,28 @@
+/**
+ * 인자로 받은 배열의 원소들 중 최소 값을 반환합니다.
+ *
+ * @example
+ * ```ts
+ * min([1, 2, 3, 4]); // 1
+ * ```
+ */
+export function min(array: number[]) {
+  return Math.min(...array);
+}
+
+/**
+ * 인자로 받은 배열을 매핑한 후 결과 값에 따라 최소 값을 가진 원소를 반환합니다.
+ *
+ * @example
+ * ```ts
+ * minBy(
+ *   [{ value: 1 }, { value: 2 }, { value: 3 }],
+ *   item => item.value
+ * ); // { value: 1 }
+ * ```
+ */
+export function minBy<T>(array: T[], mapper: (item: T) => number) {
+  return array.reduce((prev, current) => {
+    return mapper(prev) < mapper(current) ? prev : current;
+  });
+}

--- a/packages/temen/src/sum/index.ts
+++ b/packages/temen/src/sum/index.ts
@@ -1,0 +1,26 @@
+/**
+ * 인자로 받은 배열의 모든 원소를 합산합니다
+ *
+ * @example
+ * ```ts
+ * sum([1, 2, 3, 4]); // 10
+ * ```
+ */
+export function sum(array: number[]) {
+  return array.reduce((result, current) => result + current, 0);
+}
+
+/**
+ * 인자로 받은 배열을 한번 매핑한 후 모든 반환값을 합산합니다
+ *
+ * @example
+ * ```ts
+ * sumBy(
+ *   [{ value: 1 }, { value: 2 }, { value: 3 }],
+ *   item => item.value
+ * ); // 6
+ * ```
+ */
+export function sumBy<T>(array: T[], mapper: (item: T) => number) {
+  return sum(array.map((item) => mapper(item)));
+}

--- a/packages/temen/src/sum/index.ts
+++ b/packages/temen/src/sum/index.ts
@@ -22,5 +22,5 @@ export function sum(array: number[]) {
  * ```
  */
 export function sumBy<T>(array: T[], mapper: (item: T) => number) {
-  return sum(array.map((item) => mapper(item)));
+  return sum(array.map(mapper));
 }

--- a/packages/temen/test/max.test.js
+++ b/packages/temen/test/max.test.js
@@ -7,7 +7,7 @@ describe('max', () => {
   });
 });
 
-describe('sumBy', () => {
+describe('maxBy', () => {
   it('maxBy 함수는 인자로 받은 배열을 mapping한 후 최대 값을 가진 원소를 반환한다', function () {
     assert.deepStrictEqual(
       maxBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value),

--- a/packages/temen/test/max.test.js
+++ b/packages/temen/test/max.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { max, maxBy } from '../src/max';
+
+describe('max', () => {
+  it('max 함수는 인자로 받은 배열의 모든 원소 중 최대값을 반환한다', function () {
+    expect(max([1, 2, 3, 4])).toBe(4);
+  });
+});
+
+describe('sumBy', () => {
+  it('maxBy 함수는 인자로 받은 배열을 mapping한 후 최대 값을 가진 원소를 반환한다', function () {
+    assert.deepStrictEqual(
+      maxBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value),
+      { value: 4 }
+    );
+    assert.deepStrictEqual(
+      maxBy([{ name: 'evan-moon' }, { name: 'john' }], (item) => item.name.length),
+      { name: 'evan-moon' }
+    );
+  });
+});

--- a/packages/temen/test/min.test.js
+++ b/packages/temen/test/min.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { min, minBy } from '../src/min';
+
+describe('min', () => {
+  it('min 함수는 인자로 받은 배열의 모든 원소 중 최소값을 반환한다', function () {
+    expect(min([1, 2, 3, 4])).toBe(1);
+  });
+});
+
+describe('minBy', () => {
+  it('minBy 함수는 인자로 받은 배열을 mapping한 후 최소 값을 가진 원소를 반환한다', function () {
+    assert.deepStrictEqual(
+      minBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value),
+      { value: 1 }
+    );
+    assert.deepStrictEqual(
+      minBy([{ name: 'evan-moon' }, { name: 'john' }], (item) => item.name.length),
+      { name: 'john' }
+    );
+  });
+});

--- a/packages/temen/test/sum.test.js
+++ b/packages/temen/test/sum.test.js
@@ -7,7 +7,7 @@ describe('sum', () => {
 });
 
 describe('sumBy', () => {
-  it('sumBy 함수는 인자로 받은 배열을 mapping한 후 원소의 값을 합산한다 ', function () {
+  it('sumBy 함수는 인자로 받은 배열을 mapping한 후 원소의 값을 합산한다', function () {
     expect(
       sumBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value)
     ).toBe(10);

--- a/packages/temen/test/sum.test.js
+++ b/packages/temen/test/sum.test.js
@@ -1,0 +1,16 @@
+import { sum, sumBy } from '../src/sum';
+
+describe('sum', () => {
+  it('sum 함수는 인자로 받은 배열의 모든 원소를 합산한다', function () {
+    expect(sum([1, 2, 3, 4])).toBe(10);
+  });
+});
+
+describe('sumBy', () => {
+  it('sumBy 함수는 인자로 받은 배열을 mapping한 후 원소의 값을 합산한다 ', function () {
+    expect(
+      sumBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value)
+    ).toBe(10);
+    expect(sumBy([{ value: 'evan' }, { value: 'john' }], (item) => item.value.length)).toBe(8);
+  });
+});


### PR DESCRIPTION
## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

원소들의 값을 합산하는 `sum`, 최대 값을 찾는 `max`, 최소 값을 찾는 `min` 함수를 추가합니다.

`max`, `min` 같은 경우는 `Math.max`, `Math.min`이랑 다를게 없긴 한데, `maxBy`, `minBy` 같은 친구들이 은근 유용해여.
`maxBy`, `minBy` 함수가 뱉어주는 원소는 기존 배열에 있던 녀석을 그대로 반환하므로 레퍼런스가 변경되지 않습니다.

```ts
const users = [{ name: '문동욱', age: 31 }, { name: '홍길동', age: 25 }, { name: '김영란', age: 18 }];

const 평균_나이 = Math.floor(sumBy(users, ({ age }) => age) / users.length); // 24
const 제일_늙은_사람 = maxBy(users, ({ age }) => age); // { name: '문동욱', age: 31 }
const 제일_어린_사람 = minBy(users, ({ age }) => age); // { name: '김영란', age: 18 }
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 