### PR TITLE
feat(temen): unwrap하는 타입 추가

### DIFF
--- a/packages/temen/src/models/utils.ts
+++ b/packages/temen/src/models/utils.ts
@@ -1,8 +1,23 @@
-/** 제네릭으로 받은 맵의 키를 유지한 채 밸류의 타입을 Value로 변경합니다 */
+/**
+ * 제네릭으로 받은 맵의 키를 유지한 채 밸류의 타입을 Value로 변경합니다
+ */
 export type TypeMap<T, Value> = {
   [K in keyof T]: Value;
 };
 
+/**
+ * 제네릭으로 받은 맵의 키를 유지한 채 밸류의 타입을 nullable하게 변경합니다
+ */
 export type Nullable<T> = {
   [K in keyof T]: T[K] | null;
 };
+
+/**
+ * Promise<T> 타입을 T 타입으로 변환합니다
+ */
+export type UnwrapPromise<T> = T extends PromiseLike<infer U> ? U : T;
+
+/**
+ * Array<T> 타입을 T 타입으로 변환합니다
+ */
+export type UnwrapArray<T> = T extends Array<infer U> ? U : T;

--- a/packages/temen/src/models/utils.ts
+++ b/packages/temen/src/models/utils.ts
@@ -15,9 +15,9 @@ export type Nullable<T> = {
 /**
  * Promise<T> 타입을 T 타입으로 변환합니다
  */
-export type UnwrapPromise<T> = T extends PromiseLike<infer U> ? U : T;
+export type UnwrapPromise<T> = T extends PromiseLike<infer U> ? UnwrapPromise<U> : T;
 
 /**
  * Array<T> 타입을 T 타입으로 변환합니다
  */
-export type UnwrapArray<T> = T extends Array<infer U> ? U : T;
+export type UnwrapArray<T> = T extends Array<infer U> ? UnwrapArray<U> : T;


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [ ] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
예전에 만들어 둔 `Unwrap<T>` 타입 시리즈를 추가합니다. 간혹 `Promise<T>`, `Array<T>` 같은 제네릭 타입의 타입을 벗겨내야 하는 경우가 발생하는데, 요럴때 사용하는 녀석이에유.

```ts
type SingleDepthArray = UnwrapArray<string[]>; // string
type MultiDepthArray = UnwrapArray<string[][]>; // string
type UnionPromise = UnwrapArray<boolean | string[]>; // boolean | string

type SingleDepthPromise = UnwrapPromise<Promise<string>>; // string
type MultiDepthPromise = UnwrapPromise<Promise<Promise<string>>>; // string
type UnionPromise = UnwrapPromise<boolean | Promise<string>>; // boolean | string
```

사실 `UnwrapPromise<T>`는 최신 버전인 TypeScript 4.5에서 추가된 [Awaited](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements) 타입과 정확히 동일한 동작을 하는 녀석이기는 한데, 그 이하 버전에서는 요런 타입이 없었기 때문에 직접 만들어서 써야합니다.

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 