### PR TITLE
feat(temen): 평균 계산하는 함수들 추가

### DIFF
--- a/packages/temen/src/average/index.ts
+++ b/packages/temen/src/average/index.ts
@@ -1,0 +1,86 @@
+import { sum, sumBy } from '../sum';
+
+/**
+ * 인자로 받은 배열 내 원소들의 평균을 구합니다
+ *
+ * @example
+ * ```ts
+ * average([1, 2, 3, 4]); // 2.5
+ * ```
+ */
+export function average(array: number[]) {
+  return sum(array) / array.length;
+}
+
+/**
+ * 인자로 받은 배열을 한번 매핑한 후 평균을 구합니다
+ *
+ * @example
+ * ```ts
+ * averageBy(
+ *   [{ value: 1 }, { value: 2 }, { value: 3 }],
+ *   (item) => item.value,
+ * ); // 2
+ * ```
+ */
+export function averageBy<T>(array: T[], mapper: (item: T) => number) {
+  return sumBy(array, mapper) / array.length;
+}
+
+/**
+ * 이전 평균 값과 새롭게 입력된 값을 토대로 새로운 평균을 계산하는 평균 필터 알고리즘을 사용하여 값을 계산합니다.
+ *
+ * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 데이터를 들어오고 연산해야하는 곳에 적합합니다.
+ *
+ * @example
+ * ```ts
+ * let 평균조도 = 0;
+ * let 조도읽어온횟수 = 0;
+ *
+ * const 조도센서 = new AmbientLightSensor();
+ * 조도센서.onreading = () => {
+ *   조도읽어온횟수++;
+ *   평균조도 = cumulativeAverage(평균조도, 조도센서.illuminance, 조도읽어온횟수);
+ *   console.log(`지금까지의 평균 조도는 ${평균조도}lux 입니다`);
+ * };
+ *
+ * 조도센서.start();
+ * ```
+ */
+export function cumulativeAverage(prevAverage: number, newValue: number, dataListLength: number) {
+  const oldWeight = (dataListLength - 1) / dataListLength;
+  const newWeight = 1 / dataListLength;
+  return prevAverage * oldWeight + newValue * newWeight;
+}
+
+/**
+ * 이전 평균 값과 새롭게 입력된 값을 토대로 새로운 평균을 계산하는 필터 함수를 생생하며,
+ * 이전 평균 값과 현재까지의 데이터 개수는 클로저에 저장됩니다.
+ *
+ * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 데이터를 들어오고 연산해야하는 곳에 적합합니다.
+ *
+ * @example
+ * ```ts
+ * const 평균계산 = createAverageFilter();
+ * const 조도센서 = new AmbientLightSensor();
+ *
+ * 조도센서.onreading = () => {
+ *   console.log(`지금까지의 평균 조도는 ${평균계산(조도센서.illuminance)}lux 입니다`);
+ * };
+ *
+ * 조도센서.start();
+ * ```
+ */
+export function createAverageFilter(defaultDataList: number[] = []) {
+  let prevAverage = average(defaultDataList);
+  let dataList = [...defaultDataList];
+
+  return (newValue: number) => {
+    dataList = [...dataList, newValue];
+
+    const newAverage = cumulativeAverage(prevAverage, newValue, dataList.length);
+    prevAverage = newAverage;
+
+    return newAverage;
+  };
+}

--- a/packages/temen/src/average/index.ts
+++ b/packages/temen/src/average/index.ts
@@ -30,21 +30,21 @@ export function averageBy<T>(array: T[], mapper: (item: T) => number) {
 /**
  * 이전 평균 값과 새롭게 입력된 값을 토대로 새로운 평균을 계산하는 평균 필터 알고리즘을 사용하여 값을 계산합니다.
  *
- * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 데이터를 들어오고 연산해야하는 곳에 적합합니다.
+ * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 입력된 데이터를 후처리하는 상황에 적합합니다.
  *
  * @example
  * ```ts
- * let 평균조도 = 0;
- * let 조도읽어온횟수 = 0;
+ * let averageLux = 0;
+ * let calcCount = 0;
  *
- * const 조도센서 = new AmbientLightSensor();
- * 조도센서.onreading = () => {
- *   조도읽어온횟수++;
- *   평균조도 = cumulativeAverage(평균조도, 조도센서.illuminance, 조도읽어온횟수);
- *   console.log(`지금까지의 평균 조도는 ${평균조도}lux 입니다`);
+ * const sensor = new AmbientLightSensor();
+ * sensor.onreading = () => {
+ *   calcCount++;
+ *   averageLux = cumulativeAverage(averageLux, sensor.illuminance, calcCount);
+ *   console.log(`지금까지의 평균 조도는 ${averageLux}lux 입니다`);
  * };
  *
- * 조도센서.start();
+ * sensor.start();
  * ```
  */
 export function cumulativeAverage(prevAverage: number, newValue: number, dataListLength: number) {
@@ -54,26 +54,23 @@ export function cumulativeAverage(prevAverage: number, newValue: number, dataLis
 }
 
 /**
- * 이전 평균 값과 새롭게 입력된 값을 토대로 새로운 평균을 계산하는 필터 함수를 생생하며,
- * 이전 평균 값과 현재까지의 데이터 개수는 클로저에 저장됩니다.
+ * 이전 평균 값과 새롭게 입력된 값을 토대로 새로운 평균을 계산하는 클로저 필터 함수를 반환하며,
+ * 이전 평균 값과 현재까지의 데이터 개수는 createAverageFilter 함수 스코프에 자유 변수로 저장됩니다.
  *
- * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 데이터를 들어오고 연산해야하는 곳에 적합합니다.
+ * 항상 O(1)의 시간복잡도를 보장하여 평균을 계산하기 때문에, 센서 데이터 등 빠르게 입력된 데이터를 후처리하는 상황에 적합합니다.
  *
  * @example
  * ```ts
- * const 평균계산 = createAverageFilter();
- * const 조도센서 = new AmbientLightSensor();
- *
- * 조도센서.onreading = () => {
- *   console.log(`지금까지의 평균 조도는 ${평균계산(조도센서.illuminance)}lux 입니다`);
- * };
- *
- * 조도센서.start();
+ * const average = createAverageFilter();
+ * console.log(average(1)); // 1
+ * console.log(average(2)); // 1.5
+ * console.log(average(3)); // 2
+ * console.log(average(4)); // 2.5
  * ```
  */
-export function createAverageFilter(defaultDataList: number[] = []) {
-  let prevAverage = average(defaultDataList);
-  let dataList = [...defaultDataList];
+export function createAverageFilter() {
+  let prevAverage = 0;
+  let dataList: number[] = [];
 
   return (newValue: number) => {
     dataList = [...dataList, newValue];

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -44,3 +44,4 @@ export * from './intersection';
 export * from './sum';
 export * from './max';
 export * from './min';
+export * from './average';

--- a/packages/temen/test/average.test.js
+++ b/packages/temen/test/average.test.js
@@ -30,13 +30,12 @@ describe('cumulativeAverage', () => {
 
 describe('createAverageFilter', () => {
   it('createAverageFilter 함수는 이전 평균 값을 토대로 새로운 평균 값을 계산하는 필터를 생성한다', function () {
-    const defaultData = [1, 2, 3];
-    const averageFilter = createAverageFilter(defaultData);
+    const averageFilter = createAverageFilter();
 
     let avg = 0;
-    let avg2 = average(defaultData);
+    let avg2 = 0;
 
-    for (let newValue = 4; newValue < 1001; newValue++) {
+    for (let newValue = 1; newValue < 11; newValue++) {
       avg = averageFilter(newValue);
       avg2 = cumulativeAverage(avg2, newValue, newValue);
     }

--- a/packages/temen/test/average.test.js
+++ b/packages/temen/test/average.test.js
@@ -1,0 +1,46 @@
+import { average, averageBy, cumulativeAverage, createAverageFilter } from '../src/average';
+import getArrayFromCount from '../src/getArrayFromCount';
+
+const dummyNumbers = [...getArrayFromCount(999, (i) => i + 1), 1000]; // 1 ~ 1000
+
+describe('average', () => {
+  it('average 함수는 인자로 받은 배열의 모든 원소의 평균 값을 반환한다', function () {
+    expect(average(dummyNumbers)).toBe(500.5);
+  });
+});
+
+describe('averageBy', () => {
+  it('averageBy 함수는 인자로 받은 배열을 mapping한 후 원소의 값을 합산한다', function () {
+    expect(
+      averageBy([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }], (item) => item.value)
+    ).toBe(2.5);
+    expect(averageBy([{ value: 'evan' }, { value: 'john' }], (item) => item.value.length)).toBe(4);
+  });
+});
+
+describe('cumulativeAverage', () => {
+  it('cumulativeAverage 함수는 이전 평균 값을 토대로 새로운 평균 값을 계산할 수 있다', function () {
+    let avg = 0;
+    dummyNumbers.forEach((newValue) => {
+      avg = cumulativeAverage(avg, newValue, newValue);
+    });
+    expect(avg).toBe(average(dummyNumbers));
+  });
+});
+
+describe('createAverageFilter', () => {
+  it('createAverageFilter 함수는 이전 평균 값을 토대로 새로운 평균 값을 계산하는 필터를 생성한다', function () {
+    const defaultData = [1, 2, 3];
+    const averageFilter = createAverageFilter(defaultData);
+
+    let avg = 0;
+    let avg2 = average(defaultData);
+
+    for (let newValue = 4; newValue < 1001; newValue++) {
+      avg = averageFilter(newValue);
+      avg2 = cumulativeAverage(avg2, newValue, newValue);
+    }
+
+    expect(avg).toBe(avg2);
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
데이터 집합의 평균을 계산하는 함수들을 추가합니다. 

### 산술평균

주어진 데이터 집합의 합을 원소의 개수로 나누어 산술평균을 구합니다. lodash에는 [mean](https://lodash.com/docs/4.17.15#mean)으로 정의되어있는데 `average`가 좀 더 일반적인 단어인 것 같아서 변경했어유.

```ts
average([1, 2, 3]); // 2.5
averageBy([{ value: 1 }, { value: 2 }, { value: 3 }], ({ value }) => value); // 2.5
```

### 누적평균 (with 평균필터 알고리즘)

산술 평균의 최대 단점인 시간복잡도가 O(n)이라는 부분을 개선하여, 항상 O(1)의 시간복잡도를 보장하는 평균필터 알고리즘을 사용하는 함수입니다.
빠른 속도로 많은 양의 데이터가 입력되고, 그에 대한 후처리가 동반되어야하는 센서 이벤트 등의 상황에 적합합니다. 

#### cumulativeAverage

```ts
let averageLux = 0;
let calcCount = 0;

const sensor = new AmbientLightSensor();
sensor.onreading = () => {
  calcCount++;
  averageLux = cumulativeAverage(averageLux, sensor.illuminance, calcCount);
  console.log(`지금까지의 평균 조도는 ${averageLux}lux 입니다`);
};

sensor.start();
```

#### createAverageFilter
`cumulativeAverage` 함수는 사용자가 직접 "지금까지의 평균 값"과 "데이터 집합의 크기" 상태를 관리해줘야 하는 번거로움이 있기 때문에, 커링을 사용하여 이 상태들을 자유 변수로 저장해놓고 사용할 수 있는 `createAverageFilter` 함수를 추가합니다.

```ts
const average = createAverageFilter();
console.log(average(1)); // 1
console.log(average(2)); // 1.5
console.log(average(3)); // 2
console.log(average(4)); // 2.5
```

평균필터 알고리즘에 대한 설명은 제가 예전에 작성해놓은 [포스팅](https://evan-moon.github.io/2019/08/11/average-filter/)을 참고해주시면 됩니다! 🙏

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 