### PR TITLE
feat(temen): flatten 함수 추가

### DIFF
--- a/packages/temen/src/flatten/index.ts
+++ b/packages/temen/src/flatten/index.ts
@@ -1,0 +1,46 @@
+function flat<T>(arr: T[], target: unknown[], depth: number) {
+  arr.forEach(function (el) {
+    if (!Array.isArray(el) || depth === -1) {
+      target.push(el);
+      return;
+    }
+
+    flat(el, target, depth - 1);
+  });
+}
+
+/**
+ * 고차원의 배열을 Flatten 합니다. 두 번째 인자로 어느 정도의 Depth까지 탐색하여 Flatten 할지 정할 수 있습니다. 만약 Depth를 지정하지 않는다면 기본적으로 한 단계의 Flatten만 수행합니다.
+ *
+ * (Native JS의 Array.prototype.flat 메소드보다 더 빠른 속도를 보장하지만 더 많은 Heap 메모리를 사용합니다)
+ *
+ * @example
+ * ```ts
+ * flatten([[1, 2], ['hello', 'world', [ 30 ]]]);
+ * // [1, 2, 'hello', 'world', [30]]
+ *
+ * flatten([[1, 2], ['hello', 'world', [ 30 ]]], 2);
+ * // [1, 2, 'hello', 'world', 30]
+ * ```
+ */
+export function flatten<T, Depth extends number = 0>(arr: T[], depth?: Depth) {
+  const flattened: unknown[] = [];
+  flat<T>(arr, flattened, depth ?? 0);
+
+  return flattened as FlatArray<T, Depth>[];
+}
+
+/**
+ * 고차원의 배열을 끝까지 탐색하여 모든 원소를 Flatten 합니다.
+ *
+ * (Native JS의 Array.prototype.flat 메소드보다 더 빠른 속도를 보장하지만 더 많은 Heap 메모리를 사용하기 때문에, 너무 깊은 차원의 배열을 Flatten하게되면 out of memory가 발생할 수도 있습니다)
+ *
+ * @example
+ * ```ts
+ * flattenDeep([[1, 2, [3, [true]]], ['hello', 'world', [ 30 ]]]);
+ * // [1, 2, 3, true, 'hello', 'world', 30]
+ * ```
+ */
+export function flattenDeep<T>(arr: T[]) {
+  return flatten(arr, Infinity);
+}

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -48,3 +48,4 @@ export { default as isFunction } from './isFunction';
 export { default as isError } from './isError';
 export { default as isElement } from './isElement';
 export { default as memoize } from './memoize';
+export * from './flatten';

--- a/packages/temen/test/flatten.test.js
+++ b/packages/temen/test/flatten.test.js
@@ -1,0 +1,89 @@
+import assert from 'assert';
+import { flatten, flattenDeep } from '../src/flatten';
+
+describe('flatten', () => {
+  test('flatten은 인자로 받은 배열을 1 Depth Flatten 한다', () => {
+    assert.deepStrictEqual(
+      flatten([
+        [
+          [1, 23],
+          [true, true],
+        ],
+        ['ab'],
+        [1, 2],
+      ]),
+      [[1, 23], [true, true], 'ab', 1, 2]
+    );
+    assert.deepStrictEqual(
+      flatten([
+        [1, 2],
+        ['hello', 'world', [30]],
+      ]),
+      [1, 2, 'hello', 'world', [30]]
+    );
+  });
+
+  test('flatten은 두 번째 인자인 Depth만큼 재귀 Flatten을 수행한다', () => {
+    assert.deepStrictEqual(
+      flatten(
+        [
+          [
+            [1, 23],
+            [true, true],
+          ],
+          ['ab'],
+          [1, 2],
+        ],
+        2
+      ),
+      [1, 23, true, true, 'ab', 1, 2]
+    );
+  });
+
+  test('flatten은 두 번째 인자인 Depth에 -1을 넘기면 배열을 Flatten 하지 않는다', () => {
+    assert.deepStrictEqual(
+      flatten(
+        [
+          [
+            [1, 23],
+            [true, true],
+          ],
+          ['ab'],
+          [1, 2],
+        ],
+        -1
+      ),
+      [
+        [
+          [1, 23],
+          [true, true],
+        ],
+        ['ab'],
+        [1, 2],
+      ]
+    );
+  });
+});
+
+describe('flattenDeep', () => {
+  test('flattenDeep은 배열의 깊이를 끝까지 탐색하여 재귀 Flatten을 수행한다', () => {
+    assert.deepStrictEqual(
+      flattenDeep([
+        [
+          [1, 23],
+          [true, true, [{ test: 1 }]],
+        ],
+        ['ab'],
+        [1, 2],
+      ]),
+      [1, 23, true, true, { test: 1 }, 'ab', 1, 2]
+    );
+    assert.deepStrictEqual(
+      flattenDeep([
+        [1, 2, [3, [true]]],
+        ['hello', 'world', [30]],
+      ]),
+      [1, 2, 3, true, 'hello', 'world', 30]
+    );
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
고차원의 배열을 Flatten하는 `flatten`, `flattenDeep` 함수를 추가합니다.

---

### 그냥 `Array.prototype.flat` 쓰면 되지 않나요?
물론 Native JS에도 `Array.prototype.flat` 메소드가 있기는 하지만, 아직 최적화가 되지 않았다고 하는 [Stack Overflow 글](https://stackoverflow.com/questions/61411776/is-js-native-array-flat-slow-for-depth-1)을 보았는데요.

그래서 조금 리서치를 해보니까 실제로 여러가지 방법으로 flatten을 구현하고 [벤치마킹을 했던 분](https://melkornemesis.medium.com/6-different-array-flattening-methods-in-javascript-performance-testing-included-cbadd928cf62)이 있더라구요.

근데 이 두 글 모두 2020년 4월, 8월 글이라, 조금 못 미더워서 저도 저 포스팅에서 진행했던 벤치마킹 테스트를 해봤는데...

```
// small: 10depth, medium: 15depth, big: 25depth

[native] small: 0.389ms
[native] medium: 8.419ms
[native] big: 7.504s

[reduce] small: 2.132ms
[reduce] medium: 22.629ms
[reduce] big: 13.096s

[recursion] small: 0.517ms
[recursion] medium: 6.391ms
[recursion] big: 983.285ms
```

NodeJS 14.17.3 기준으로 아직 `Array.prototype.flat` 메소드의 최적화가 이루어지지 않았길래, 재귀 방식으로 직접 구현했읍니다.

### `flatten`을 lodash의 `flattenDepth`처럼 구현한 이유
lodash의 [flatten](https://lodash.com/docs/4.17.15#flatten)은 무조건 1depth의 flatten만 수행하는 함수이고, 직접 depth 값을 넘겨서 원하는 깊이만큼 flatten을 하려면 [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth) 함수를 사용하도록 되어있는데요.

이 두 개를 굳이 나눌 필요가 없는 것 같아서 그냥 `flatten(arr: T[], depth?: number)`처럼 Depth 값을 옵셔널하게 받도록 만들었습니다.

Native JS의 `Array.prototype.flat` 메소드도 depth 값을 옵셔널하게 받는 형태로 설계되어 있기 때문에, 오히려 이게 더 DX에도 더 좋을 것 같아요.

```ts
flatten([[1, 2], ['hello', 'world', [ 30 ]]]);
// [1, 2, 'hello', 'world', [30]]

flatten([[1, 2], ['hello', 'world', [ 30 ]]], 2);
// [1, 2, 'hello', 'world', 30]

flattenDeep([[1, 2, [3, [true]]], ['hello', 'world', [ 30 ]]]);
// [1, 2, 3, true, 'hello', 'world', 30]
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow: