### PR TITLE
feat(temen): 문자열 포맷 함수 시리즈 추가

### DIFF
--- a/packages/temen/src/_internal/convertFirstLetter.ts
+++ b/packages/temen/src/_internal/convertFirstLetter.ts
@@ -1,0 +1,8 @@
+export function convertFirstLetter(text: string, formatter: (char: string) => string) {
+  if (text.length === 0) {
+    return text;
+  }
+
+  const [first, ...rest] = text;
+  return `${formatter(first)}${rest.join('')}`;
+}

--- a/packages/temen/src/_internal/convertSpecialCharacters.ts
+++ b/packages/temen/src/_internal/convertSpecialCharacters.ts
@@ -1,0 +1,20 @@
+import { trimCharacters } from '../trimCharacters';
+import { upperFirstLetter } from '../convertFirstLetter';
+
+export function splitByUpperCase(text: string, splitter: string[]) {
+  if (text === '') {
+    return text;
+  }
+
+  const escapeSplitter = splitter.map((c) => (c === ' ' ? '\\s' : c));
+
+  const regex = new RegExp(`[${escapeSplitter.join('')}]|(?=[A-Z][a-z])`);
+  const words = trimCharacters(text, escapeSplitter).split(regex);
+  return words
+    .map((word, index) => {
+      const [firstCharacter, ...rest] = word;
+      const lowerRest = rest.join('').toLowerCase();
+      return index === 0 ? `${firstCharacter}${lowerRest}` : upperFirstLetter(word.toLowerCase());
+    })
+    .join('');
+}

--- a/packages/temen/src/camelCase/index.ts
+++ b/packages/temen/src/camelCase/index.ts
@@ -1,0 +1,18 @@
+import { lowerFirstLetter } from '../convertFirstLetter';
+import { splitByUpperCase } from '../_internal/convertSpecialCharacters';
+
+/**
+ * 인자로 받은 문자열을 Camel Case로 변환합니다.
+ *
+ * splitter 인자에 아무런 값을 주지 않을 경우 공백, -, _ 기준으로 단어를 구분합니다.
+ *
+ * @example
+ * ```ts
+ * camelCase('FooBar'); // fooBar
+ * camelCase('foo-bar'); // fooBar
+ * camelCase('foo&bar', ['&']); // fooBar
+ * ```
+ */
+export function camelCase(text: string, splitter = [' ', '-', '_']) {
+  return lowerFirstLetter(splitByUpperCase(text, splitter));
+}

--- a/packages/temen/src/convertFirstLetter/index.ts
+++ b/packages/temen/src/convertFirstLetter/index.ts
@@ -1,0 +1,25 @@
+import { convertFirstLetter } from '../_internal/convertFirstLetter';
+
+/**
+ * 주어진 문자열의 첫 번째 문자를 소문자로 변경합니다
+ *
+ * @example
+ * ```ts
+ * lowerFirstLetter('FRED'); // fRED
+ * ```
+ */
+export function lowerFirstLetter(text: string) {
+  return convertFirstLetter(text, (char) => char.toLowerCase());
+}
+
+/**
+ * 주어진 문자열의 첫 번째 문자를 대문자로 변경합니다
+ *
+ * @example
+ * ```ts
+ * upperFirstLetter('fred'); // Fred
+ * ```
+ */
+export function upperFirstLetter(text: string) {
+  return convertFirstLetter(text, (char) => char.toUpperCase());
+}

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -50,3 +50,7 @@ export { default as isError } from './isError';
 export { default as isElement } from './isElement';
 export { default as memoize } from './memoize';
 export * from './flatten';
+export * from './parscalCase';
+export * from './camelCase';
+export * from './trimCharacters';
+export * from './convertFirstLetter';

--- a/packages/temen/src/parscalCase/index.ts
+++ b/packages/temen/src/parscalCase/index.ts
@@ -1,0 +1,18 @@
+import { upperFirstLetter } from '../convertFirstLetter';
+import { splitByUpperCase } from '../_internal/convertSpecialCharacters';
+
+/**
+ * 인자로 받은 문자열을 Parscal Case로 변환합니다.
+ *
+ * splitter 인자에 아무런 값을 주지 않을 경우 공백, -, _ 기준으로 단어를 구분합니다.
+ *
+ * @example
+ * ```ts
+ * parscalCase('fooBar'); // FooBar
+ * parscalCase('foo-bar'); // FooBar
+ * parscalCase('foo&bar', ['&']); // FooBar
+ * ```
+ */
+export function parscalCase(text: string, splitter = [' ', '-', '_']) {
+  return upperFirstLetter(splitByUpperCase(text, splitter));
+}

--- a/packages/temen/src/trimCharacters/index.ts
+++ b/packages/temen/src/trimCharacters/index.ts
@@ -1,0 +1,44 @@
+/**
+ * 대상 문자열 중 targetCharacters에 포함되는 문자를 Start Trim합니다. targetCharacters에 아무런 값을 주지 않는 경우에는 공백을 Trim 합니다.
+ *
+ * @example
+ * ```ts
+ * trimStartCharacters('    foo'); // foo
+ * trimStartCharacters('--foo', ['-']); // foo
+ * ```
+ */
+export function trimStartCharacters(text: string, targetCharacters: string[] = [' ']) {
+  const char = targetCharacters.join('');
+  const regex = `^[${char}]+`;
+  return text.replace(new RegExp(regex), '');
+}
+
+/**
+ * 대상 문자열 중 targetCharacters에 포함되는 문자를 End Trim합니다. targetCharacters에 아무런 값을 주지 않는 경우에는 공백을 Trim 합니다.
+ *
+ * @example
+ * ```ts
+ * trimEndCharacters('foo    '); // foo
+ * trimEndCharacters('foo--', ['-']); // foo
+ * ```
+ */
+export function trimEndCharacters(text: string, targetCharacters: string[] = [' ']) {
+  const char = targetCharacters.join('');
+  const regex = `[${char}]+$`;
+  return text.replace(new RegExp(regex), '');
+}
+
+/**
+ * 대상 문자열 중 targetCharacters에 포함되는 문자를 Trim합니다. targetCharacters에 아무런 값을 주지 않는 경우에는 공백을 Trim 합니다.
+ *
+ * @example
+ * ```ts
+ * trimCharacters('   foo    '); // foo
+ * trimCharacters('--foo--', ['-']); // foo
+ * trimCharacters('--_foo-_-', ['-', '_']); // foo
+ * ```
+ */
+export function trimCharacters(text: string, targetCharacters: string[]) {
+  const startTrimmed = trimStartCharacters(text, targetCharacters);
+  return trimEndCharacters(startTrimmed, targetCharacters);
+}

--- a/packages/temen/test/camelCase.test.js
+++ b/packages/temen/test/camelCase.test.js
@@ -1,0 +1,20 @@
+import { camelCase } from '../src';
+
+describe('camelCase', () => {
+  test('camelCase는 인자로 받은 문자열을 Camel Case로 변경한다', () => {
+    expect(camelCase('camelCase')).toBe('camelCase');
+    expect(camelCase('123CamelCase')).toBe('123CamelCase');
+    expect(camelCase('Hello World')).toBe('helloWorld');
+    expect(camelCase('snake_case')).toBe('snakeCase');
+    expect(camelCase('kebab-case')).toBe('kebabCase');
+    expect(camelCase('123-kebab-case')).toBe('123KebabCase');
+    expect(camelCase('--FOO-bar--')).toBe('fooBar');
+    expect(camelCase('__Init__')).toBe('init');
+    expect(camelCase('HELLO_WORLD')).toBe('helloWorld');
+    expect(camelCase('')).toBe('');
+  });
+  test('camelCase는 두 번째 인자에 받은 문자열 리스트를 Splitter로 인식한다', () => {
+    expect(camelCase('foo&bar', ['&'])).toBe('fooBar');
+    expect(camelCase('foo&bar-baz', ['&', '-'])).toBe('fooBarBaz');
+  });
+});

--- a/packages/temen/test/convertFirstLetter.test.js
+++ b/packages/temen/test/convertFirstLetter.test.js
@@ -1,0 +1,14 @@
+import { lowerFirstLetter, upperFirstLetter } from '../src';
+
+describe('convertFirstLetter', () => {
+  test('lowerFirstLetter 함수는 문자열의 첫 글자를 소문자로 변경한다', () => {
+    expect(lowerFirstLetter('FRED')).toBe('fRED');
+    expect(lowerFirstLetter('1FRED')).toBe('1FRED');
+    expect(lowerFirstLetter('')).toBe('');
+  });
+  test('upperFirstLetter 함수는 문자열의 첫 글자를 대문자로 변경한다', () => {
+    expect(upperFirstLetter('fred')).toBe('Fred');
+    expect(upperFirstLetter('1fred')).toBe('1fred');
+    expect(upperFirstLetter('')).toBe('');
+  });
+});

--- a/packages/temen/test/parscalCase.test.js
+++ b/packages/temen/test/parscalCase.test.js
@@ -1,0 +1,20 @@
+import { parscalCase } from '../src';
+
+describe('parscalCase', () => {
+  test('parscalCase는 인자로 받은 문자열을 Parscal Case로 변경한다', () => {
+    expect(parscalCase('camelCase')).toBe('CamelCase');
+    expect(parscalCase('123CamelCase')).toBe('123CamelCase');
+    expect(parscalCase('Hello World')).toBe('HelloWorld');
+    expect(parscalCase('snake_case')).toBe('SnakeCase');
+    expect(parscalCase('kebab-case')).toBe('KebabCase');
+    expect(parscalCase('123-kebab-case')).toBe('123KebabCase');
+    expect(parscalCase('--FOO-bar--')).toBe('FooBar');
+    expect(parscalCase('__Init__')).toBe('Init');
+    expect(parscalCase('HELLO_WORLD')).toBe('HelloWorld');
+    expect(parscalCase('')).toBe('');
+  });
+  test('parscalCase는 두 번째 인자에 받은 문자열 리스트를 Splitter로 인식한다', () => {
+    expect(parscalCase('foo&bar', ['&'])).toBe('FooBar');
+    expect(parscalCase('foo&bar-baz', ['&', '-'])).toBe('FooBarBaz');
+  });
+});

--- a/packages/temen/test/trimCharacters.test.js
+++ b/packages/temen/test/trimCharacters.test.js
@@ -1,0 +1,24 @@
+import { trimCharacters, trimStartCharacters, trimEndCharacters } from '../src';
+
+describe('trimStartCharacters', () => {
+  test('trimStartCharacters 함수는 인자로 받은 문자열 내에서 지정한 문자를 Start Trim한다', () => {
+    expect(trimStartCharacters('    foo')).toBe('foo');
+    expect(trimStartCharacters('--foo', ['-'])).toBe('foo');
+  });
+});
+
+describe('trimEndCharacters', () => {
+  test('trimEndCharacters 함수는 인자로 받은 문자열 내에서 지정한 문자를 End Trim한다', () => {
+    expect(trimEndCharacters('foo    ')).toBe('foo');
+    expect(trimEndCharacters('foo--', ['-'])).toBe('foo');
+  });
+});
+
+describe('trimCharacters', () => {
+  test('trimCharacters 함수는 인자로 받은 문자열 내에서 지정한 문자를 Trim한다', () => {
+    expect(trimCharacters('   foo    ')).toBe('foo');
+    expect(trimCharacters('--foo--', ['-'])).toBe('foo');
+    expect(trimCharacters('--_foo-_-', ['-', '_'])).toBe('foo');
+    expect(trimCharacters('-_-foo-_-', ['-_-'])).toBe('foo');
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
`parscalCase`, `camelCase`, `upperFirstLetter`, `lowerFirstLetter`, `trimCharacters`, `trimStartCharacters`, `trimEndCharacters` 함수를 추가합니다.

### parscalCase, camelCase

인자로 받은 문자열을 각각 ParscalCase, camelCase로 변환합니다. 두 번째 인자인 splitter를 사용하면 특정한 문자를 기준으로 단어가 나누어졌다는 것을 표현할 수 있습니다. (왜인지 모르겠지만 `parscalCase`함수는 lodash에 없어서 추가했슴다)

```ts
parscalCase('camelCase'); // CamelCase
parscalCase('foo&bar-baz', ['&', '-']); // FooBarBaz

camelCase('ParscalCase'); // parscalCase
camelCase('foo&bar-baz', ['&', '-']); // fooBarBaz
```

### upperFirstLetter, lowerFirstLetter

인자로 받은 문자열의 가장 첫 번째 문자를 대,소문자로 변경합니다. 가장 첫 번째 문자가 영문이 아닌 경우 변경을 수행하지 않습니다.

```ts
lowerFirstLetter('FRED'); // fRED
lowerFirstLetter('1FRED'); // 1FRED

upperFirstLetter('fred'); // Fred
upperFirstLetter('1fred'); // 1fred
```

### trimCharacters, trimStartCharacters, trimEndCharacters

기본적으로는 공백을 찾아 trimming하지만, `targetCharacter` 인자에 값을 추가하면 해당 문자들을 찾아서 trimming합니다.

```ts
trimStartCharacters('    foo'); // foo
trimStartCharacters('--foo', ['-']); // foo

trimEndCharacters('foo    '); // foo
trimEndCharacters('foo--', ['-']); // foo

trimCharacters('   foo    '); // foo
trimCharacters('--_foo-_-', ['-', '_']); // foo
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 