### PR TITLE
feat(browser-toolkit): loadScript 함수 추가

### DIFF
--- a/packages/browser-toolkit/src/index.ts
+++ b/packages/browser-toolkit/src/index.ts
@@ -14,3 +14,4 @@ export * from './copyToClipboard';
 export * from './fetch';
 export * from './cookies';
 export * from './querystring';
+export * from './loadScript';

--- a/packages/browser-toolkit/src/loadScript/index.ts
+++ b/packages/browser-toolkit/src/loadScript/index.ts
@@ -2,6 +2,21 @@ interface Options {
   async?: boolean;
   defer?: boolean;
 }
+
+/**
+ * 비동기적으로 스크립트를 로드하고 실행합니다. 로드가 완료되면 Promise가 resolve됩니다.
+ *
+ * 함수의 두 번째 인자로 async, defer 속성을 추가할 수도 있으며, 기본 값은 async = true , defer = true입니다.
+ *
+ * @example
+ * ```ts
+ * function loadGoogleSDK () {
+ *   return loadScript('https://developers.kakao.com/sdk/js/kakao.js');
+ *   // 또는
+ *   return loadScript('https://developers.kakao.com/sdk/js/kakao.js', { async: false, defer: true });
+ * }
+ * ```
+ */
 export function loadScript(src: string, options: Options = {}) {
   const { async = true, defer = true } = options;
   if (window == null || document == null) {

--- a/packages/browser-toolkit/src/loadScript/index.ts
+++ b/packages/browser-toolkit/src/loadScript/index.ts
@@ -10,11 +10,8 @@ interface Options {
  *
  * @example
  * ```ts
- * function loadGoogleSDK () {
- *   return loadScript('https://developers.kakao.com/sdk/js/kakao.js');
- *   // 또는
- *   return loadScript('https://developers.kakao.com/sdk/js/kakao.js', { async: false, defer: true });
- * }
+ * await loadScript('https://developers.kakao.com/sdk/js/kakao.js');
+ * window.Kakao.init('my-token');
  * ```
  */
 export function loadScript(src: string, options: Options = {}) {

--- a/packages/browser-toolkit/src/loadScript/index.ts
+++ b/packages/browser-toolkit/src/loadScript/index.ts
@@ -6,7 +6,7 @@ interface Options {
 /**
  * 비동기적으로 스크립트를 로드하고 실행합니다. 로드가 완료되면 Promise가 resolve됩니다.
  *
- * 함수의 두 번째 인자로 async, defer 속성을 추가할 수도 있으며, 기본 값은 async = true , defer = true입니다.
+ * 함수의 두 번째 인자로 async, defer 속성을 추가할 수도 있으며, 기본 값은 async = true , defer = false입니다.
  *
  * @example
  * ```ts
@@ -15,7 +15,7 @@ interface Options {
  * ```
  */
 export function loadScript(src: string, options: Options = {}) {
-  const { async = true, defer = true } = options;
+  const { async = true, defer = false } = options;
   if (window == null || document == null) {
     console.warn('loadScript 함수는 브라우저가 아닌 환경에서 실행될 수 없습니다.');
     return Promise.resolve();

--- a/packages/browser-toolkit/src/loadScript/index.ts
+++ b/packages/browser-toolkit/src/loadScript/index.ts
@@ -1,0 +1,27 @@
+interface Options {
+  async?: boolean;
+  defer?: boolean;
+}
+export function loadScript(src: string, options: Options = {}) {
+  const { async = true, defer = true } = options;
+  if (window == null || document == null) {
+    console.warn('loadScript 함수는 브라우저가 아닌 환경에서 실행될 수 없습니다.');
+    return Promise.resolve();
+  }
+
+  const element = document.querySelector(`script[src="${src}"]`);
+  if (element) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.async = async;
+    script.defer = defer;
+    script.src = src;
+
+    document.body.appendChild(script);
+
+    script.addEventListener('load', resolve);
+  });
+}

--- a/packages/browser-toolkit/src/loadScript/index.ts
+++ b/packages/browser-toolkit/src/loadScript/index.ts
@@ -15,7 +15,6 @@ interface Options {
  * ```
  */
 export function loadScript(src: string, options: Options = {}) {
-  const { async = true, defer = false } = options;
   if (window == null || document == null) {
     console.warn('loadScript 함수는 브라우저가 아닌 환경에서 실행될 수 없습니다.');
     return Promise.resolve();
@@ -26,6 +25,7 @@ export function loadScript(src: string, options: Options = {}) {
     return Promise.resolve();
   }
 
+  const { async = true, defer = false } = options;
   return new Promise((resolve) => {
     const script = document.createElement('script');
     script.async = async;


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [ ] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
비동기적으로 외부에서 스크립트를 불러오는 `loadScript` 함수를 추가합니다. 함수의 두 번째 인자로 `async`, `defer` 속성을 넘길 수 있습니다.

```ts
await loadScript('https://developers.kakao.com/sdk/js/kakao.js');
window.Kakao.init('my-token');
```

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow: