### PR TITLE
feat(browser-toolkit): 통신에 실패했을 때 fetch 함수 내부에서 명시적으로 에러를 던지도록 수정

### DIFF
--- a/packages/browser-toolkit/src/fetch/index.ts
+++ b/packages/browser-toolkit/src/fetch/index.ts
@@ -48,7 +48,13 @@ export function createFetchInstance(baseUrl: string, options?: RequestOptions) {
 
 export async function doRequest<T>(url: string, options?: RequestOptions) {
   const response = await fetch(url, requestHandler({ ...options }));
-  return responseHandler<T>(response);
+  const lubyconResponse = await responseHandler<T>(response);
+
+  if (lubyconResponse.status === 'failed') {
+    throw lubyconResponse;
+  }
+
+  return lubyconResponse;
 }
 
 export function doGet<T>(url: string, options?: WithoutRequestBodyOptions) {

--- a/packages/browser-toolkit/src/fetch/models.ts
+++ b/packages/browser-toolkit/src/fetch/models.ts
@@ -1,0 +1,18 @@
+export interface LubyconSuccessResponse<T> {
+  headers: Record<string, string>;
+  body: T;
+  statusCode: number;
+  statusText: string;
+  status: 'success';
+}
+
+export interface LubyconErrorResponse {
+  headers: Record<string, string>;
+  body: null;
+  statusCode: number;
+  statusText: string;
+  status: 'failed';
+  reason?: string;
+}
+
+export type LubyconResponse<T> = LubyconSuccessResponse<T> | LubyconErrorResponse;

--- a/packages/browser-toolkit/src/fetch/utils.ts
+++ b/packages/browser-toolkit/src/fetch/utils.ts
@@ -13,3 +13,7 @@ export function convertHeadersToObject(headers: Headers) {
 
   return data;
 }
+
+export function isSucceedResponse(status: number) {
+  return status >= 200 && status < 400;
+}


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [ ] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
현재 `LubyconResponse<T>` 인터페이스는 요청 성공, 에러 상태를 모두 포함하고 있기 때문에 `LubyconResponse<T>.data`의 nullish 여부를 통해서만 요청 실패 여부를 파악할 수 있습니다.

`responseHandler`에서 명시적으로 상태코드 200 이상 400미만 코드에 대해서만 성공처리를 하도록 변경하고, 나머지 상태코드는 직접 `LubyconErrorResponse` 객체를 throw 하도록 변경하여, fetch 함수 외부에서 `try/catch`로 에러 처리를 용이하게 할 수 있도록 변경합니다.

1. `react-query`의 `data`프로퍼티와 겹치지 않도록 `LubyconResponse` 타입이 응답 바디를 `data`가 아니라 `body` 프로퍼티를 사용하여 내보내도록 수정. (`data.data`처럼 접근하지 않기 위함)
2. `LubyconSuccessResponse`로 평가된 경우, `body` 가 `T | null`이 아닌 `T`임을 보장하여 요청이 성공했을때 `LubyconSuccessResponse.body`의 nullish 여부를 체크하지 않아도 되도록 수정.
3. `LubyconErrorResponse`로 평가된 경우, `body`가  반드시 `null`임을 보장하고 에러가 발생한 이유가 상태 코드 때문인지, 응답 바디를 파싱하다 발생한 것인지를 구분.

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 