### PR TITLE
feat(react): SSRSuspense 추가

### DIFF
--- a/packages/react/src/components/SSRSuspense.tsx
+++ b/packages/react/src/components/SSRSuspense.tsx
@@ -5,7 +5,7 @@ import { ComponentProps, Suspense, useEffect, useState } from 'react';
  * SSR 환경에서는 fallback를 렌더하고, CSR 환경에서는 Suspsense를 렌더하는 컴포넌트입니다.
  *
  * @example
- * ```tsx
+ * ```jsx
  * <SSRSuspense fallback={<Fallback />}>
  *   <MyPage />
  * </SSRSuspense>

--- a/packages/react/src/components/SSRSuspense.tsx
+++ b/packages/react/src/components/SSRSuspense.tsx
@@ -11,7 +11,7 @@ import { ComponentProps, Suspense, useEffect, useState } from 'react';
  * </SSRSuspense>
  * ```
  */
-export default function SSRSuspense({ fallback, children }: ComponentProps<typeof Suspense>) {
+export function SSRSuspense({ fallback, children }: ComponentProps<typeof Suspense>) {
   const [isMounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/packages/react/src/components/SSRSuspense.tsx
+++ b/packages/react/src/components/SSRSuspense.tsx
@@ -1,0 +1,46 @@
+import React, { ComponentType, ReactNode } from 'react';
+import { ComponentProps, Suspense, useEffect, useState } from 'react';
+
+/**
+ * SSR 환경에서는 fallback를 렌더하고, CSR 환경에서는 Suspsense를 렌더하는 컴포넌트입니다.
+ *
+ * @example
+ * ```tsx
+ * <SSRSuspense fallback={<Fallback />}>
+ *   <MyPage />
+ * </SSRSuspense>
+ * ```
+ */
+export default function SSRSuspense({ fallback, children }: ComponentProps<typeof Suspense>) {
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (isMounted) {
+    return <Suspense fallback={fallback}>{children}</Suspense>;
+  }
+  return <>{fallback}</>;
+}
+
+/**
+ * SSRSuspense를 HoC로 사용할 수 있는 함수입니다
+ *
+ * @example
+ * ```ts
+ * export default withSSRSuspense(<MyPage />, { fallback: <Fallback /> });
+ * ```
+ */
+export function withSSRSuspense<T>(
+  WrappedComponent: ComponentType<T>,
+  options: { fallback: NonNullable<ReactNode> | null }
+) {
+  return (props: T) => {
+    return (
+      <SSRSuspense fallback={options.fallback}>
+        <WrappedComponent {...(props as any)} />
+      </SSRSuspense>
+    );
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,3 +26,4 @@ export { default as useScrollEvent } from './hooks/useScrollEvent';
 export { default as useClipboardCopy } from './hooks/useClipboardCopy';
 export { default as useResizeObserver } from './hooks/useResizeObserver';
 export { default as useElementSize } from './hooks/useElementSize';
+export * from './components/SSRSuspense';


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [ ] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

아직 Next와 같은 SSR 환경에서 Suspense가 제대로 지원되고 있지 않기 때문에, Suspense를 사용하려면 SSR, CSR 환경에 따른 예외처리를 따로 해줘야 합니다.
그런 이유로 SSR 환경에서는 fallback을 렌더하는 `SSRSuspense` 컴포넌트와 `withSSRSuspense` HoC를 추가하여, 이 예외처리를 위임할 수 있도록 합니다.

```jsx
<SSRSuspense fallback={<Loading />}>
  <MyPage />
</SSRSuspense>

// or

export default withSSRSuspense(<MyPage />, { fallback: <Loading /> });
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
:bow:
