### PR TITLE
fix(temen): getArrayFromCount의 반환 타입이 unknown[]으로 잡히는 이슈 수정

### DIFF
--- a/packages/temen/src/getArrayFromCount/index.ts
+++ b/packages/temen/src/getArrayFromCount/index.ts
@@ -1,3 +1,5 @@
+import { identify } from '../functions';
+
 /**
  * 인자로 받은 숫자만큼의 길이를 가진 배열을 반환합니다. 두 번째 인자의 mapper를 넘기지 않으면, 인덱스를 원소 값으로 가집니다.
  *
@@ -5,6 +7,11 @@
  * getArrayFromCount(5) // [0, 1, 2, 3, 4];
  * getArrayFromCount(5, i => `${i}!`); // ['0!', '1!', '2!', '3!', '4!']
  */
-export default function getArrayFromCount<T>(count: number, mapper?: (i: number) => T) {
-  return Array.from({ length: count }, (_, i) => mapper?.(i) ?? i);
+function getArrayFromCount(count: number): number[];
+function getArrayFromCount<T>(count: number, mapper: (i: number) => T): T[];
+function getArrayFromCount<T>(count: number, mapper?: (i: number) => T) {
+  const array = Array.from<number>({ length: count });
+  return array.map((v) => mapper?.(v) ?? identify(v));
 }
+
+export default getArrayFromCount;

--- a/packages/temen/src/getArrayFromCount/index.ts
+++ b/packages/temen/src/getArrayFromCount/index.ts
@@ -10,7 +10,7 @@ import { identify } from '../functions';
 function getArrayFromCount(count: number): number[];
 function getArrayFromCount<T>(count: number, mapper: (i: number) => T): T[];
 function getArrayFromCount<T>(count: number, mapper?: (i: number) => T) {
-  const array = Array.from<number>({ length: count });
+  const array = Array.from({ length: count }, (_, index) => index);
   return array.map((v) => mapper?.(v) ?? identify(v));
 }
 

--- a/packages/temen/test/getArrayFromCount.test.js
+++ b/packages/temen/test/getArrayFromCount.test.js
@@ -1,0 +1,14 @@
+import getArrayFromCount from '../src/getArrayFromCount';
+
+describe('getArrayFromCount', () => {
+  test('getArrayFromCount은 인자로 길이를 가진 순차 값 배열을 생성한다', () => {
+    expect(getArrayFromCount(2)).toStrictEqual([0, 1]);
+    expect(getArrayFromCount(5)).toStrictEqual([0, 1, 2, 3, 4]);
+    expect(getArrayFromCount(10)).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  test('getArrayFromCount는 배열을 생성할 때 mapper를 사용하여 값을 변형할 수 있다', () => {
+    expect(getArrayFromCount(5, (v) => `${v}!`)).toStrictEqual(['0!', '1!', '2!', '3!', '4!']);
+    expect(getArrayFromCount(5, (v) => v * 2)).toStrictEqual([0, 2, 4, 6, 8]);
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항
`getArrayFromCount` 함수의 반환 타입이 항상 `unknown[]`으로 잡히는 이슈를 제대로 된 오버로딩을 통해 수정합니다.

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 