### PR TITLE
fix(temen): mapKeys, mapValues 설명 수정

### DIFF
--- a/packages/temen/src/mapKeys/index.ts
+++ b/packages/temen/src/mapKeys/index.ts
@@ -1,25 +1,15 @@
-/**
- * "object"와 동일한 값을 가진 객체를 만들고 "iterate"를 통해
- * "object"의 각 열거형 문자열 키 속성을 이용해 새로운 생성된 키를 생성한합니다.
- *
- * 'object'의 키 속성을 'iterate'를 통해 문자열화합니다.
- * iterate는 세 가지 인수(value, key, object)로 호출됩니다.
- *
- * @param {Object} object 반복할 객체
- * @param {Function} iterate 반복당 호출 함수
- * @returns {Object} 키 값이 새로 매핑 된 객체
- *
- * @example
- * ```js
- * mapKeys({ 'a': 1, 'b': 2 }, function(value, key) {
- *   return key + value;
- * });
- * // => { 'a1': 1, 'b2': 2 }
- * ```
- */
-
 import getObjectKeys from '../getObjectKeys';
 
+/**
+ * 객체를 순회하며 키를 매핑하여, 값을 유지한 채 새로운 키를 가진 객체를 생성합니다.
+ *
+ *
+ * @example
+ * ```ts
+ * mapKeys({ a: 1, b: 2 }, (value, key) => key + value);
+ * // => { a1: 1, b2: 2 }
+ * ```
+ */
 function mapKeys<T>(
   object: T,
   iterate: (value: T[keyof T], key: keyof T, object: T) => string | number

--- a/packages/temen/src/mapValues/index.ts
+++ b/packages/temen/src/mapValues/index.ts
@@ -1,29 +1,19 @@
-/**
- * 'object'와 동일한 키를 가진 객체를 만들고
- * 'object'의 각 열거형 문자열 키 속성을 이용해
- * iterate는 세 가지 인수(value, key, object)로 호출됩니다.
- *
- * @param {Object} object 반복할 객체
- * @param {Function} iterate 반복당 호출 함수
- * @returns {Object} 매핑된 새 객체를 반환합니다.
- *
- * @example
- * ```js
- * const users = {
- *   'fred':    { 'user': 'fred',    'age': 40 },
- *   'pebbles': { 'user': 'pebbles', 'age': 1 }
- * };
- *
- * mapValues(users, function(o) { return o.age; });
- * // => { 'fred': 40, 'pebbles': 1 }
- *
- * mapValues(users, 'age');
- * // => { 'fred': 40, 'pebbles': 1 }
- * ```
- */
-
 import getObjectKeys from '../getObjectKeys';
 
+/**
+ * 객체를 순회하며 값을 매핑하여, 키를 유지한채 새로운 값을 가진 객체를 생성합니다.
+ *
+ * @example
+ * ```ts
+ * const users = {
+ *   fred: { name: 'fred', age: 40 },
+ *   pebbles: { name: 'pebbles', age: 1 }
+ * };
+ *
+ * mapValues(users, (o) => o.age);
+ * // => { fred: 40, pebbles: 1 }
+ * ```
+ */
 function mapValues<T>(
   object: T,
   iterate: (value: T[keyof T], key: keyof T, object: T) => string | number

--- a/packages/temen/test/mapObject.test.js
+++ b/packages/temen/test/mapObject.test.js
@@ -1,10 +1,12 @@
 import { mapKeys, mapValues } from '../src';
 
-describe('mapKeys, mapValues', () => {
+describe('mapKeys', () => {
   test('mapKeys 함수는 "object"와 동일한 값을 가진 객체를 만들고 "iterate"를 통해 "object"의 각 열거형 문자열 키 속성을 이용해 새로운 생성된 키를 생성한다.', () => {
     expect(mapKeys({ a: 1, b: 2 }, (value, key) => key + value)).toStrictEqual({ a1: 1, b2: 2 });
   });
+});
 
+describe('mapValues', () => {
   test('mapValues "object"와 동일한 키를 가진 객체를 만들고 "object"의 각 열거형 문자열 키 속성을 이용해 iterate는 세 가지 인수(value, key, object)로 호출된다.', () => {
     expect(
       mapValues(


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [ ] 내가 만든 모듈을 `export` 했나요?
- [ ] 테스트는 작성했나요?
- [ ] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

`mapKeys`, `mapValues`의 jsDoc을 업데이트합니다.

- 타입으로 추론되는 파라미터를 주석에서 제거합니다.
- 함수의 설명을 더 추상적으로 자연어에 가깝게 표현합니다.
- `mapValues(users, 'age')`과 같이 실제 함수가 지원하지 않는 케이스를 설명에서 제거합니다.
- `mapKeys`와 `mapValues`의 유닛 테스트를 명시적으로 분리합니다.

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
