### PR TITLE
feat(temen): replaceItem, preserveRefReplaceItem, iif 추가

### DIFF
--- a/packages/temen/src/iif/index.ts
+++ b/packages/temen/src/iif/index.ts
@@ -1,0 +1,12 @@
+/**
+ * 첫 번째 인자로 조건을 받아, 조건 결과에 따라 참, 거짓에 해당하는 값을 반환합니다.
+ */
+export function iif<T>(condition: boolean, trueResult: T): T | undefined;
+export function iif<T>(condition: true, trueResult: T): T;
+export function iif<T>(condition: false, trueResult: T): undefined;
+export function iif<T, K>(condition: boolean, trueResult: T, falseResult: K): T | K;
+export function iif<T, K>(condition: true, trueResult: T, falseResult: K): T;
+export function iif<T, K>(condition: false, trueResult: T, falseResult: K): K;
+export function iif<T, K>(condition: boolean, trueResult: T, falseResult?: K) {
+  return condition ? trueResult : falseResult;
+}

--- a/packages/temen/src/index.ts
+++ b/packages/temen/src/index.ts
@@ -69,3 +69,5 @@ export * from './lt';
 export { default as omit } from './omit';
 export { default as mapKeys } from './mapKeys';
 export { default as mapValues } from './mapValues';
+export { iif } from './iif';
+export { replaceItem, preserveRefReplaceItem } from './replaceItem';

--- a/packages/temen/src/replaceItem/index.ts
+++ b/packages/temen/src/replaceItem/index.ts
@@ -1,0 +1,18 @@
+import { iif } from '../iif';
+
+/**
+ * 배열 내 지정된 인덱스에 위치한 원소를 새로운 원소로 변경하고 새로운 배열을 반환합니다.
+ */
+export function replaceItem<T>(arr: T[], targetIndex: number, newItem: T) {
+  return arr.map((item, index) => {
+    return iif(index === targetIndex, newItem, item);
+  });
+}
+
+/**
+ * 배열 내 지정된 인덱스에 위치한 원소를 새로운 원소로 변경하고 원본 배열을 반환합니다.
+ */
+export function preserveRefReplaceItem<T>(arr: T[], targetIndex: number, newItem: T) {
+  arr[targetIndex] = newItem;
+  return arr;
+}

--- a/packages/temen/src/replaceItem/index.ts
+++ b/packages/temen/src/replaceItem/index.ts
@@ -1,7 +1,7 @@
 import { iif } from '../iif';
 
 /**
- * 배열 내 지정된 인덱스에 위치한 원소를 새로운 원소로 변경하고 새로운 배열을 반환합니다.
+ * 배열 내 지정된 인덱스에 위치한 원소를 새로운 원소로 변경하고 새로운 배열을 반환합니다. 대상 배열은 얕은 복사 되기 때문에 내부 원소들의 레퍼런스는 변하지 않습니다.
  */
 export function replaceItem<T>(arr: T[], targetIndex: number, newItem: T) {
   return arr.map((item, index) => {

--- a/packages/temen/src/replaceItem/index.ts
+++ b/packages/temen/src/replaceItem/index.ts
@@ -13,6 +13,9 @@ export function replaceItem<T>(arr: T[], targetIndex: number, newItem: T) {
  * 배열 내 지정된 인덱스에 위치한 원소를 새로운 원소로 변경하고 원본 배열을 반환합니다.
  */
 export function preserveRefReplaceItem<T>(arr: T[], targetIndex: number, newItem: T) {
+  if (targetIndex < 0 || targetIndex > arr.length - 1) {
+    throw new Error('targetIndex의 값이 유효하지 않습니다.');
+  }
   arr[targetIndex] = newItem;
   return arr;
 }

--- a/packages/temen/test/iif.test.js
+++ b/packages/temen/test/iif.test.js
@@ -1,0 +1,17 @@
+import { iif } from '../src/iif';
+
+describe('iif', () => {
+  test('iif 함수는 첫 번째 인자의 결과가 참일 경우 반드시 두 번째 인자를 반환한다', () => {
+    expect(iif(true, 1)).toBe(1);
+    expect(iif(true, 1, 2)).toBe(1);
+  });
+
+  test('iif 함수는 첫 번째 인자의 결과가 거짓일 경우 반드시 세 번째 인자를 반환한다.', () => {
+    expect(iif(false, 1, 2)).toBe(2);
+    expect(iif(false, 1, 'foo')).toBe('foo');
+  });
+
+  test('iif 함수는 첫 번째 인자의 결과가 거짓이지만 세 번째 인자가 없는 경우에는 undefined를 반환한다.', () => {
+    expect(iif(false, 1)).toBe(undefined);
+  });
+});

--- a/packages/temen/test/replaceItem.test.js
+++ b/packages/temen/test/replaceItem.test.js
@@ -15,4 +15,9 @@ describe('replaceItem', () => {
     expect(preserveRefReplaceItem(array, 2, 5)).toStrictEqual([1, 2, 5]);
     expect(preserveRefReplaceItem(array, 2, 5)).toBe(array);
   });
+  it('preserveRefReplaceItem 함수는 유효하지 않은 인덱스 값을 받았을 때 에러를 반환한다.', function () {
+    const array = [1, 2, 3];
+    expect(() => preserveRefReplaceItem(array, 100, 5)).toThrow(Error);
+    expect(() => preserveRefReplaceItem(array, -1, 5)).toThrow(Error);
+  });
 });

--- a/packages/temen/test/replaceItem.test.js
+++ b/packages/temen/test/replaceItem.test.js
@@ -6,7 +6,11 @@ describe('replaceItem', () => {
     expect(replaceItem(array, 2, 5)).toStrictEqual([1, 2, 5]);
     expect(replaceItem(array, 2, 5)).not.toBe(array);
   });
-  it('preserveRefReplaceItem 함수는 특정 인덱스의 원소를 업데이트하고 원본 배열을 반환한다..', function () {
+  it('replaceItem 함수는 대상 배열을 얕은 복사한다.', function () {
+    const array = [1, 2, 3];
+    expect(replaceItem(array, 2, 5)[0]).toBe(array[0]);
+  });
+  it('preserveRefReplaceItem 함수는 특정 인덱스의 원소를 업데이트하고 원본 배열을 반환한다.', function () {
     const array = [1, 2, 3];
     expect(preserveRefReplaceItem(array, 2, 5)).toStrictEqual([1, 2, 5]);
     expect(preserveRefReplaceItem(array, 2, 5)).toBe(array);

--- a/packages/temen/test/replaceItem.test.js
+++ b/packages/temen/test/replaceItem.test.js
@@ -1,0 +1,14 @@
+import { replaceItem, preserveRefReplaceItem } from '../src/replaceItem';
+
+describe('replaceItem', () => {
+  it('replaceItem 함수는 특정 인덱스의 원소를 업데이트하고 새로운 배열을 반환한다.', function () {
+    const array = [1, 2, 3];
+    expect(replaceItem(array, 2, 5)).toStrictEqual([1, 2, 5]);
+    expect(replaceItem(array, 2, 5)).not.toBe(array);
+  });
+  it('preserveRefReplaceItem 함수는 특정 인덱스의 원소를 업데이트하고 원본 배열을 반환한다..', function () {
+    const array = [1, 2, 3];
+    expect(preserveRefReplaceItem(array, 2, 5)).toStrictEqual([1, 2, 5]);
+    expect(preserveRefReplaceItem(array, 2, 5)).toBe(array);
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

### replaceItem, preserveRefReplaceItem

배열 내에서 원하는 원소를 Replace할 수 있는 `replaceItem`, `preserveRefReplaceItem` 함수를 추가합니다.

```ts
const foo = [1, 2, 3];
const replacedFoo = replaceItem(foo, 2, 5); // [1, 2, 5]
console.log(foo === replacedFoo); // false, 원본 배열 foo를 건드리지 않고 새로운 배열을 생성함

const bar = [1, 2, 3];
preserveRefReplaceItem(bar, 2, 5); 
console.log(bar); // [1, 2, 5], 원본 배열 bar를 직접 변경함
```

### iif
`rxjs`의 `iif`와 유사하게 첫 번째 인자의 참/거짓 결과에 따라 해당하는 값을 반환하는 `iif` 함수를 추가합니다.

```ts
import { iif } from '@quotalab/utils';

const env = iif(typeof window === undefined, 'server', 'client');

const newSignatures = signatures.map(signature => 
  iif(signature.id === selectedSignature, signature, null)
)
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
지금 만드는 사이드 프로젝트에서 `replaceItem`이 필요함 ㅜㅜㅜㅜ