### PR TITLE
feat(react): add useTabVisibility

### DIFF
--- a/packages/react/src/hooks/useTabVisibility.ts
+++ b/packages/react/src/hooks/useTabVisibility.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 /**
  *
@@ -14,17 +14,13 @@ import { useEffect, useState } from 'react';
  *
  */
 
-function useTabVisibility(onTabVisible: () => void, onTabHidden: () => void) {
-  const [isTabVisible, setTabVisible] = useState(document.visibilityState === 'visible');
-
+function useTabVisibility(onVisible: () => void, onHidden: () => void) {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        setTabVisible(true);
-        onTabVisible();
+        onVisible();
       } else {
-        setTabVisible(false);
-        onTabHidden();
+        onHidden();
       }
     };
 
@@ -34,8 +30,6 @@ function useTabVisibility(onTabVisible: () => void, onTabHidden: () => void) {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
-
-  return isTabVisible;
 }
 
 export default useTabVisibility;

--- a/packages/react/src/hooks/useTabVisibility.ts
+++ b/packages/react/src/hooks/useTabVisibility.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+/**
+ *
+ * page visibility API를 사용하여 사용자가 웹사이트에서 활성 상태인지 비활성 상태인지 확인합니다.
+ *
+ * @param {Function} onTabVisible 탭이 활성화되었을 때 호출될 함수
+ * @param {Function} onTabHidden 탭이 비활성화되었을 때 호출될 함수
+ *
+ * @example
+ * ```javascript
+ * const isTabVisible = useTabVisibility(callRepeatApi, pauseRepeatApi);
+ * ```
+ *
+ */
+
+function useTabVisibility(onTabVisible: () => void, onTabHidden: () => void) {
+  const [isTabVisible, setTabVisible] = useState(document.visibilityState === 'visible');
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        setTabVisible(true);
+        onTabVisible();
+      } else {
+        setTabVisible(false);
+        onTabHidden();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isTabVisible;
+}
+
+export default useTabVisibility;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,3 +31,4 @@ export { default as useDetectEscapeKey } from './hooks/useDetectEscapeKey';
 export { default as useDetectKeyPress } from './hooks/useDetectKeyPress';
 export * from './hooks/useOverlay';
 export * from './components/Portal';
+export { default as useTabVisibility } from './hooks/useTabVisibility';


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [ ] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

-  page visibility API를 사용하여 사용자가 웹사이트에서 활성 상태인지 비활성 상태인지 확인합니다.
- 사용자가 활성 상태가 아니면 무거운 백그라운드 프로세스를 중지하기 위해 사용 할 수 있습니다.


> Developers have historically used imperfect proxies to detect this. For example, watching for [blur](https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event) and [focus](https://developer.mozilla.org/en-US/docs/Web/API/Window/focus_event) events on the window helps you know when your page is not the active page, but it does not tell you that your page is actually hidden to the user. The Page Visibility API addresses this. - [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
