### PR TITLE
feat(temen): entries 함수 추가

### DIFF
--- a/packages/temen/src/entries/index.ts
+++ b/packages/temen/src/entries/index.ts
@@ -1,0 +1,18 @@
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+/**
+ * 인자로 받은 객체를 `[key, value]`의 배열로 변경하여 반환합니다.
+ *
+ * Object.entries 메소드와 동일한 동작을 제공하지만, 객체의 key를 `string`으로 추론하지 않고 `keyof T`로 더 정밀하게 추론합니다.
+ *
+ * @example
+ * ```ts
+ * const foo = { name: 'john', age: 31 };
+ * entries(foo); // [['name', 'john'], ['age', 31]]
+ * ```
+ */
+export function entries<T>(object: T) {
+  return Object.entries(object) as Entries<T>;
+}

--- a/packages/temen/test/entries.test.js
+++ b/packages/temen/test/entries.test.js
@@ -1,0 +1,16 @@
+import { entries } from '../src/entries';
+
+describe('entries', () => {
+  test('entries는 인자로 받은 객체의 키와 값으로 이루어진 배열을 반환한다', () => {
+    const obj = {
+      name: 'john',
+      age: 13,
+    };
+
+    expect(entries(obj)).toStrictEqual([
+      ['name', 'john'],
+      ['age', 13],
+    ]);
+    expect(entries(obj)).toStrictEqual(Object.entries(obj));
+  });
+});


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(utils): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 체크해보기

- [x] 내가 만든 모듈을 `export` 했나요?
- [x] 테스트는 작성했나요?
- [x] 내가 만든 모듈에 대한 설명이 `jsDoc` 포맷으로 잘 입력되어있나요?

## 변경사항

`Object.entries`와 동일한 동작이지만 결과 값의 타입을 더 정밀하게 추론하는 `entries` 함수를 추가합니다.

 ```ts
const foo = { name: 'john', age: 31 };

const entry = entries(foo); // Entry<{ name: string; age: number }>
const element = entry[0]; // ["name", string] | ["age", number] => 키와 값의 쌍을 추론할 수 있다

const originEntry = Object.entries(foo); // [string, string | number][]
const element2 = originEntry[0]; // [string, string | number]
```

<!-- 
ex.
### utils
- querystring 관련 유틸 추가
### mattermost
- querystring 유틸을 사용하기 위한 utils 디펜던시 설치
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 
